### PR TITLE
Merge with latest developments from EHJ-52n

### DIFF
--- a/52n-sos-importer-feeder/pom.xml
+++ b/52n-sos-importer-feeder/pom.xml
@@ -61,6 +61,10 @@
 			<groupId>org.n52.sensorweb</groupId>
 			<artifactId>52n-oxf-xmlbeans</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.n52.sensorweb</groupId>
+            <artifactId>oxf-third-party-ncname-resolver</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>


### PR DESCRIPTION
Solve build error in feeder by adding missing dependency `org.n52.sensorweb::oxf-third-party-ncname-resolver`
