### PR TITLE
Fix npe when parsing timestamps

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -28,6 +28,7 @@ For a complete Release Notes overview visit
  * #nn: Fix handling of data files with multiple date & time columns
  * #nn: Fix bug in unix time parsing
  * #nn: Fix typo in xml schema: expresssion -> expression
+ * #78: NullPointerException when parsing Date/Time
  
 
 # Release Notes for SOS-Importer 0.4.0

--- a/feeder/pom.xml
+++ b/feeder/pom.xml
@@ -20,7 +20,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>52n-sos-importer-bindings</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/feeder/pom.xml
+++ b/feeder/pom.xml
@@ -20,6 +20,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>52n-sos-importer-bindings</artifactId>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/Configuration.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/Configuration.java
@@ -77,7 +77,6 @@ import org.x52North.sensorweb.sos.importer.x04.UnitOfMeasurementType;
  */
 public final class Configuration {
 
-
     /**
      * Constant <code>SOS_200_EPSG_CODE_PREFIX="http://www.opengis.net/def/crs/EPSG/0/"</code>
      */
@@ -170,7 +169,7 @@ public final class Configuration {
     public static final String DEFAULT_CHARSET = "UTF-8";
 
     /** Constant <code>EPSG_EASTING_FIRST_MAP</code> */
-    private static HashMap<String, Boolean> EPSG_EASTING_FIRST_MAP;
+    private static final HashMap<String, Boolean> EPSG_EASTING_FIRST_MAP;
 
     private static final Logger LOG = LoggerFactory.getLogger(Configuration.class);
 
@@ -187,7 +186,7 @@ public final class Configuration {
     private static final String KM = "km";
 
     static {
-        EPSG_EASTING_FIRST_MAP = new HashMap<String, Boolean>();
+        EPSG_EASTING_FIRST_MAP = new HashMap<>();
         EPSG_EASTING_FIRST_MAP.put("default", false);
         EPSG_EASTING_FIRST_MAP.put("4326", false);
         EPSG_EASTING_FIRST_MAP.put("4979", false);

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/Configuration.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/Configuration.java
@@ -214,20 +214,6 @@ public final class Configuration {
     private Pattern localeFilePattern;
 
     /**
-     * For testing only!
-     *
-     * @param importConf a {@link SosImportConfiguration} object.
-     */
-    protected Configuration(final SosImportConfiguration importConf) {
-        if (importConf == null) {
-            throw new IllegalArgumentException("SosImportConfiguration MUST NOT be null or INVALID");
-        }
-        this.importConf = importConf;
-        configFile = null;
-        setLocaleFilePattern();
-    }
-
-    /**
      * <p>Constructor for Configuration.</p>
      *
      * @param pathToFile a {@link java.lang.String} object.

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
@@ -591,7 +591,8 @@ public class DataFile {
                         return TimeZone.getDefault();
                     }
                 }
-                if (meta.getKey().equals(Key.PARSE_PATTERN) && (meta.getValue().contains("Z") || meta.getValue().contains("X"))) {
+                if (meta.getKey().equals(Key.PARSE_PATTERN) && (meta.getValue().contains("Z") ||
+                        meta.getValue().contains("X"))) {
                     return null;
                 }
             }
@@ -976,16 +977,16 @@ public class DataFile {
         TemporalAccessor ta = dtf.parse(timestampPart);
 
         if (ta.isSupported(field)) {
-        	return ta.get(field);
+            return ta.get(field);
         }
 
         throw new ParseException("Could not parse field '"
-        		+ field.toString()
-        		 + "' using pattern '"
-        		 + pattern
-        		 + "' for input '"
-        		 + timestampPart
-        		 + "'. (Ingore offset value).",-42);
+                + field.toString()
+                 + "' using pattern '"
+                 + pattern
+                 + "' for input '"
+                 + timestampPart
+                 + "'. (Ingore offset value).", -42);
     }
 
     private ChronoField[] getChronoFields(final String pattern) {
@@ -1029,7 +1030,7 @@ public class DataFile {
             for (final Metadata m : column.getMetadataArray()) {
                 if (m.getKey().equals(Key.PARSE_PATTERN)) {
                     String pattern = m.getValue();
-					LOG.debug(String.format("Parsepattern found: %s",
+                    LOG.debug(String.format("Parsepattern found: %s",
                                 pattern));
                     return pattern;
                 }
@@ -1041,18 +1042,18 @@ public class DataFile {
         return null;
     }
 
-	private void checkPattern(String pattern) throws ParseException {
-		if (pattern.contains("z")) {
-			StringBuilder errorMsg = new StringBuilder();
-			errorMsg.append("Pattern 'z' not supported. Found in pattern '");
-			errorMsg.append(pattern);
-			errorMsg.append("'.");
-			LOG.error(errorMsg.toString());
-			throw new ParseException(
-					errorMsg.toString(),
-					pattern.indexOf('z'));
-		}
-	}
+    private void checkPattern(String pattern) throws ParseException {
+        if (pattern.contains("z")) {
+            StringBuilder errorMsg = new StringBuilder();
+            errorMsg.append("Pattern 'z' not supported. Found in pattern '");
+            errorMsg.append(pattern);
+            errorMsg.append("'.");
+            LOG.error(errorMsg.toString());
+            throw new ParseException(
+                    errorMsg.toString(),
+                    pattern.indexOf('z'));
+        }
+    }
 
     /** {@inheritDoc} */
     @Override

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
@@ -969,9 +969,6 @@ public class DataFile {
         sdf.setTimeZone(timeZone);
 
         String parsebleTimestamp = timestampPart;
-        if (timestampPart.indexOf('Z') != -1) {
-            parsebleTimestamp = timestampPart.replaceAll("Z", "+0100");
-        }
 
         date = sdf.parse(parsebleTimestamp);
 

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
@@ -982,38 +982,38 @@ public class DataFile {
         LOG.trace(String.format("getGregorianCalendarFields(%s)",
                     pattern));
         final ArrayList<Integer> fields = new ArrayList<Integer>();
-        if (pattern.indexOf("y") != -1) {
+        if (pattern.contains("y")) {
             fields.add(GregorianCalendar.YEAR);
         }
-        if (pattern.indexOf("M") != -1 ||
-                pattern.indexOf("w") != -1 ||
-                pattern.indexOf("D") != -1) {
+        if (pattern.contains("M") ||
+                pattern.contains("w") ||
+                pattern.contains("D")) {
             fields.add(GregorianCalendar.MONTH);
         }
-        if (pattern.indexOf("d") != -1 ||
-                (pattern.indexOf("W") != -1 && pattern.indexOf("d") != -1)) {
+        if (pattern.contains("d") ||
+                (pattern.contains("W") && pattern.contains("d"))) {
             fields.add(GregorianCalendar.DAY_OF_MONTH);
         }
-        if (pattern.indexOf("H") != -1 ||
-                pattern.indexOf("k") != -1 ||
-                ((pattern.indexOf("K") != -1 ||
-                (pattern.indexOf("h") != -1) && pattern.indexOf("a") != -1))) {
+        if (pattern.contains("H") ||
+                pattern.contains("k") ||
+                ((pattern.contains("K") ||
+                (pattern.contains("h")) && pattern.contains("a")))) {
             fields.add(GregorianCalendar.HOUR_OF_DAY);
         }
-        if (pattern.indexOf("m") != -1) {
+        if (pattern.contains("m")) {
             fields.add(GregorianCalendar.MINUTE);
         }
-        if (pattern.indexOf("s") != -1) {
+        if (pattern.contains("s")) {
             fields.add(GregorianCalendar.SECOND);
         }
-        if (pattern.indexOf("Z") != -1 || pattern.indexOf("z") != -1) {
+        if (pattern.contains("Z") || pattern.contains("z")) {
             fields.add(GregorianCalendar.ZONE_OFFSET);
         }
         fields.trimToSize();
         final int[] result = new int[fields.size()];
         int j = 0;
         for (final Integer i : fields) {
-            result[j++] = i.intValue();
+            result[j++] = i;
         }
         return result;
     }

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/DataFile.java
@@ -970,7 +970,7 @@ public class DataFile {
                     field));
         DateTimeFormatter dtf = DateTimeFormatter.ofPattern(pattern);
         if (timeZone != null) {
-        	dtf.withZone(ZoneId.of(timeZone.getID()));
+            dtf = dtf.withZone(ZoneId.of(timeZone.getID()));
         }
 
         TemporalAccessor ta = dtf.parse(timestampPart);

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/SensorObservationService.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/SensorObservationService.java
@@ -687,7 +687,7 @@ public final class SensorObservationService {
         // TIMESTAMP
         final Timestamp timeStamp = dataFile.getTimeStamp(mVColumnId, values);
         if (isSampleBasedDataFile) {
-            if (lastTimestamp != null && timeStamp.before(lastTimestamp)) {
+            if (lastTimestamp != null && timeStamp.isBefore(lastTimestamp)) {
                 sampleDate.applyDayDelta(1);
             }
             lastTimestamp = new Timestamp().enrich(timeStamp);

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/csv/NSAMParser.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/csv/NSAMParser.java
@@ -207,13 +207,13 @@ public class NSAMParser implements CsvParser {
         cal.setTime(parsedDate);
         final long newMillis = cal.getTimeInMillis() + Integer.parseInt(secondsElapsed) * 1000;
         cal.setTimeInMillis(newMillis);
-        timestamp.setYear((short) cal.get(GregorianCalendar.YEAR));
-        timestamp.setMonth((byte) (cal.get(GregorianCalendar.MONTH) + 1));
-        timestamp.setDay((byte) cal.get(GregorianCalendar.DAY_OF_MONTH));
-        timestamp.setHour((byte) cal.get(GregorianCalendar.HOUR_OF_DAY));
-        timestamp.setMinute((byte) cal.get(GregorianCalendar.MINUTE));
-        timestamp.setSeconds((byte) cal.get(GregorianCalendar.SECOND));
-        timestamp.setTimezone((byte) 0);
+        timestamp.setYear(cal.get(GregorianCalendar.YEAR));
+        timestamp.setMonth((cal.get(GregorianCalendar.MONTH) + 1));
+        timestamp.setDay(cal.get(GregorianCalendar.DAY_OF_MONTH));
+        timestamp.setHour(cal.get(GregorianCalendar.HOUR_OF_DAY));
+        timestamp.setMinute(cal.get(GregorianCalendar.MINUTE));
+        timestamp.setSeconds(cal.get(GregorianCalendar.SECOND));
+        timestamp.setTimezone(0);
         return timestamp;
     }
 

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/csv/NSAMParser.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/csv/NSAMParser.java
@@ -208,7 +208,7 @@ public class NSAMParser implements CsvParser {
         final long newMillis = cal.getTimeInMillis() + Integer.parseInt(secondsElapsed) * 1000;
         cal.setTimeInMillis(newMillis);
         timestamp.setYear(cal.get(GregorianCalendar.YEAR));
-        timestamp.setMonth((cal.get(GregorianCalendar.MONTH) + 1));
+        timestamp.setMonth(cal.get(GregorianCalendar.MONTH) + 1);
         timestamp.setDay(cal.get(GregorianCalendar.DAY_OF_MONTH));
         timestamp.setHour(cal.get(GregorianCalendar.HOUR_OF_DAY));
         timestamp.setMinute(cal.get(GregorianCalendar.MINUTE));

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/model/TimeSeries.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/model/TimeSeries.java
@@ -343,7 +343,7 @@ public class TimeSeries {
     private String getResultTime() {
         Timestamp resultTime = null;
         for (final InsertObservation io : timeseries) {
-            if (resultTime == null || resultTime.before(io.getTimeStamp())) {
+            if (resultTime == null || resultTime.isBefore(io.getTimeStamp())) {
                 resultTime = io.getTimeStamp();
             }
         }
@@ -357,10 +357,10 @@ public class TimeSeries {
         Timestamp start = null;
         Timestamp end = null;
         for (final InsertObservation io : timeseries) {
-            if (start == null || start.after(io.getTimeStamp())) {
+            if (start == null || start.isAfter(io.getTimeStamp())) {
                 start = io.getTimeStamp();
             }
-            if (end == null || end.before(io.getTimeStamp())) {
+            if (end == null || end.isBefore(io.getTimeStamp())) {
                 end = io.getTimeStamp();
             }
         }

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
@@ -52,6 +52,7 @@ import java.util.regex.PatternSyntaxException;
  */
 public class Timestamp {
 
+    private static final String UTC = "UTC";
     private static final String SINGLE_ZERO = "0";
     private static final String DOUBLE_ZERO = SINGLE_ZERO + SINGLE_ZERO;
     private static final String PARAMETER_TIME_STAMP_IS_MANDATORY = "parameter timeStamp is mandatory.";
@@ -142,21 +143,56 @@ public class Timestamp {
      * @return a {@link org.n52.sos.importer.feeder.model.Timestamp} object.
      */
     public Timestamp ofUnixTimeMillis(final long unixTimeMillis) {
-        OffsetDateTime timestamp = OffsetDateTime.ofInstant(Instant.ofEpochMilli(unixTimeMillis),ZoneId.of("UTC"));
+        OffsetDateTime timestamp = OffsetDateTime.ofInstant(Instant.ofEpochMilli(unixTimeMillis), ZoneId.of(UTC));
         year = timestamp.getYear();
         month = timestamp.getMonthValue();
         day = timestamp.getDayOfMonth();
         hour = timestamp.getHour();
         minute = timestamp.getMinute();
         seconds = timestamp.getSecond();
-        millis = timestamp.getNano()/1000;
-        timezone = timestamp.getOffset().getTotalSeconds()/3600;
+        millis = timestamp.getNano() / 1000;
+        timezone = timestamp.getOffset().getTotalSeconds() / 3600;
+        return this;
+    }
+
+    /**
+     * <p>enrich with values from another timestamp.</p>
+     *
+     * @param other a {@link Timestamp} object.
+     * @return a {@link Timestamp} object.
+     */
+    public Timestamp enrich(final Timestamp other) {
+        if (other != null) {
+            if (other.getYear() > Integer.MIN_VALUE) {
+                setYear(other.getYear());
+            }
+            if (other.getMonth() > Integer.MIN_VALUE) {
+                setMonth(other.getMonth());
+            }
+            if (other.getDay() > Integer.MIN_VALUE) {
+                setDay(other.getDay());
+            }
+            if (other.getHour() > Integer.MIN_VALUE) {
+                setHour(other.getHour());
+            }
+            if (other.getMinute() > Integer.MIN_VALUE) {
+                setMinute(other.getMinute());
+            }
+            if (other.getSeconds() > Integer.MIN_VALUE) {
+                setSeconds(other.getSeconds());
+            }
+            if (other.getTimezone() > Integer.MIN_VALUE) {
+                setTimezone(other.getTimezone());
+            }
+            if (other.getMillis() > Integer.MIN_VALUE) {
+                setMillis(other.getMillis());
+            }
+        }
         return this;
     }
 
     /**
      * <p>enrich.</p>
-     * @deprecated
      * @param timestampInformation the filename that might contain additional information
      *          for the {@link org.n52.sos.importer.feeder.model.Timestamp}
      * @param regExToExtractFileInfo a {@link java.lang.String} object.
@@ -218,7 +254,6 @@ public class Timestamp {
 
     /**
      * <p>enrich.</p>
-     * @deprecated
      * @param lastModified long
      * @param lastModifiedDeltaDays -1, if it should be ignored, else &gt; 0.
      * @return a {@link Timestamp} object.
@@ -230,46 +265,10 @@ public class Timestamp {
         if (lastModifiedDeltaDays > 0) {
             lastModifiedTmp = lastModified - (lastModifiedDeltaDays * MILLIS_PER_DAY);
         }
-        ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(lastModifiedTmp), ZoneId.of("UTC"));
+        ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(lastModifiedTmp), ZoneId.of(UTC));
         setYear(zdt.get(ChronoField.YEAR));
         setMonth(zdt.get(ChronoField.MONTH_OF_YEAR));
         setDay(zdt.get(ChronoField.DAY_OF_MONTH));
-        return this;
-    }
-
-    /**
-     * <p>enrich with values from another timestamp.</p>
-     *
-     * @param other a {@link Timestamp} object.
-     * @return a {@link Timestamp} object.
-     */
-    public Timestamp enrich(final Timestamp other) {
-        if (other != null) {
-            if (other.getYear() > Integer.MIN_VALUE) {
-                setYear(other.getYear());
-            }
-            if (other.getMonth() > Integer.MIN_VALUE) {
-                setMonth(other.getMonth());
-            }
-            if (other.getDay() > Integer.MIN_VALUE) {
-                setDay(other.getDay());
-            }
-            if (other.getHour() > Integer.MIN_VALUE) {
-                setHour(other.getHour());
-            }
-            if (other.getMinute() > Integer.MIN_VALUE) {
-                setMinute(other.getMinute());
-            }
-            if (other.getSeconds() > Integer.MIN_VALUE) {
-                setSeconds(other.getSeconds());
-            }
-            if (other.getTimezone() > Integer.MIN_VALUE) {
-                setTimezone(other.getTimezone());
-            }
-            if (other.getMillis() > Integer.MIN_VALUE) {
-                setMillis(other.getMillis());
-            }
-        }
         return this;
     }
 
@@ -281,16 +280,24 @@ public class Timestamp {
         String iso8601String = toISO8601String();
         try {
             return dtf.parse(iso8601String, ZonedDateTime::from).toInstant();
-        } catch (DateTimeException e) {}
+        } catch (DateTimeException e) {
+            //
+        }
         try {
             return dtf.parse(iso8601String, OffsetDateTime::from).toInstant();
-        } catch (DateTimeException e) {}
+        } catch (DateTimeException e) {
+            //
+        }
         try {
-            return dtf.parse(iso8601String, LocalDateTime::from).toInstant(ZoneOffset.of("UTC"));
-        } catch (DateTimeException e) {}
+            return dtf.parse(iso8601String, LocalDateTime::from).toInstant(ZoneOffset.of(UTC));
+        } catch (DateTimeException e) {
+            //
+        }
         try {
-            return Instant.ofEpochMilli(dtf.parse(iso8601String, LocalDate::from).toEpochDay()*MILLIS_PER_DAY);
-        } catch (DateTimeException e) {}
+            return Instant.ofEpochMilli(dtf.parse(iso8601String, LocalDate::from).toEpochDay() * MILLIS_PER_DAY);
+        } catch (DateTimeException e) {
+            //
+        }
         return Instant.ofEpochMilli(0);
     }
 
@@ -380,7 +387,10 @@ public class Timestamp {
         if (ta.isSupported(ChronoField.YEAR) &&
                 ta.isSupported(ChronoField.MONTH_OF_YEAR) &&
                 ta.isSupported(ChronoField.DAY_OF_MONTH)) {
-            LocalDate ld = LocalDate.of(ta.get(ChronoField.YEAR), ta.get(ChronoField.MONTH_OF_YEAR), ta.get(ChronoField.DAY_OF_MONTH));
+            LocalDate ld = LocalDate.of(
+                    ta.get(ChronoField.YEAR),
+                    ta.get(ChronoField.MONTH_OF_YEAR),
+                    ta.get(ChronoField.DAY_OF_MONTH));
             ld = ld.plusDays(daysToAdd);
             setYear(ld.getYear());
             setMonth(ld.getMonthValue());

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
@@ -28,12 +28,20 @@
  */
 package org.n52.sos.importer.feeder.model;
 
+import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -41,9 +49,14 @@ import java.util.regex.PatternSyntaxException;
 /**
  * <p>Timestamp class.</p>
  *
- * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
- *
  * TODO switch to Joda time or java 8 to get time zone problems fixed
+ * Notes for implementation
+ * - getter => use the java.time equivalents
+ * - setter => use java.time.obj.with(...) -> returning objects
+ * - differ between timezone offset and timezone id based timestamps
+ *  ZonedDateTime OffsetDateTime
+ *
+ * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
  * @version $Id: $Id
  */
 public class Timestamp {
@@ -55,108 +68,105 @@ public class Timestamp {
     private static final String MM = "mm:";
     private static final long MILLIS_PER_HOUR = 1000 * 60 * 60;
     private static final long MILLIS_PER_DAY = MILLIS_PER_HOUR * 24;
-    private short year = Short.MIN_VALUE;
-    private byte month = Byte.MIN_VALUE;
-    private byte day = Byte.MIN_VALUE;
-    private byte hour = Byte.MIN_VALUE;
-    private byte minute = Byte.MIN_VALUE;
-    private byte seconds = Byte.MIN_VALUE;
+    private int year = Integer.MIN_VALUE;
+    private int month = Integer.MIN_VALUE;
+    private int day = Integer.MIN_VALUE;
+    private int hour = Integer.MIN_VALUE;
+    private int minute = Integer.MIN_VALUE;
+    private int seconds = Integer.MIN_VALUE;
     private int millis = Integer.MIN_VALUE;
-    private byte timezone = Byte.MIN_VALUE;
+    private int timezone = Integer.MIN_VALUE;
 
     /** {@inheritDoc} */
     @Override
+    @Deprecated
     public String toString() {
+    	return toISO8601String();
+    }
+
+    public String toISO8601String() {
         // yyyy-MM-ddTHH:mm:ss+hh:mm => 31 chars
         final StringBuilder ts = new StringBuilder(31);
-        if (year != Short.MIN_VALUE) {
+        if (year != Integer.MIN_VALUE) {
             ts.append(year);
-            if (month != Byte.MIN_VALUE) {
+            if (month != Integer.MIN_VALUE) {
                 ts.append("-");
             }
         }
-        if (month != Byte.MIN_VALUE) {
+        if (month != Integer.MIN_VALUE) {
             ts.append(month < 10 ? SINGLE_ZERO + month : month);
-            if (day != Byte.MIN_VALUE) {
+            if (day != Integer.MIN_VALUE) {
                 ts.append("-");
             }
         }
-        if (day != Byte.MIN_VALUE) {
+        if (day != Integer.MIN_VALUE) {
             ts.append(day < 10 ? SINGLE_ZERO + day : day);
         }
-        if ((year != Short.MIN_VALUE || month != Byte.MIN_VALUE || day != Byte.MIN_VALUE)
-                && (hour != Byte.MIN_VALUE || minute != Byte.MIN_VALUE || seconds != Byte.MIN_VALUE)) {
+        if ((year != Integer.MIN_VALUE || month != Integer.MIN_VALUE || day != Integer.MIN_VALUE)
+                && (hour != Integer.MIN_VALUE || minute != Integer.MIN_VALUE || seconds != Integer.MIN_VALUE)) {
             ts.append("T");
         }
-        if (hour != Byte.MIN_VALUE) {
+        if (hour != Integer.MIN_VALUE) {
             ts.append(hour < 10 ? SINGLE_ZERO + hour : hour);
-            if (minute != Byte.MIN_VALUE) {
+            if (minute != Integer.MIN_VALUE) {
                 ts.append(":");
             }
         }
-        if (minute != Byte.MIN_VALUE) {
+        if (minute != Integer.MIN_VALUE) {
             ts.append(minute < 10 ? SINGLE_ZERO + minute : minute).append(":");
-        } else if (hour != Byte.MIN_VALUE) {
+        } else if (hour != Integer.MIN_VALUE) {
             ts.append(DOUBLE_ZERO);
             ts.append(":");
         }
-        if (seconds != Byte.MIN_VALUE) {
+        if (seconds != Integer.MIN_VALUE) {
             ts.append(seconds < 10 ? SINGLE_ZERO + seconds : seconds);
-        } else if (minute != Byte.MIN_VALUE && hour != Byte.MIN_VALUE) {
+        } else if (minute != Integer.MIN_VALUE && hour != Integer.MIN_VALUE) {
             ts.append(DOUBLE_ZERO);
         }
         if (millis != Integer.MIN_VALUE) {
             ts.append(".").append(millis < 10 ? DOUBLE_ZERO + millis : (millis < 100 ? SINGLE_ZERO + millis : millis));
         }
-        if (timezone != Byte.MIN_VALUE &&
-                (hour != Byte.MIN_VALUE || minute != Byte.MIN_VALUE || seconds != Byte.MIN_VALUE)) {
-            ts.append(convertTimeZone(timezone));
+        if (timezone != Integer.MIN_VALUE &&
+                (hour != Integer.MIN_VALUE || minute != Integer.MIN_VALUE || seconds != Integer.MIN_VALUE)) {
+        	if (timezone >= 0) {
+                if (timezone >= 10) {
+                    ts.append("+").append(timezone).append(":").append(DOUBLE_ZERO);
+                } else {
+                	ts.append("+0").append(timezone).append(":").append(DOUBLE_ZERO);
+                }
+            } else {
+                if (timezone <= -10) {
+                	ts.append(timezone).append(":").append(DOUBLE_ZERO);
+                } else {
+                	ts.append("-0").append(Math.abs(timezone)).append(":").append(DOUBLE_ZERO);
+                }
+            }
         }
         return ts.toString();
     }
 
-    private String convertTimeZone(final int timeZone) {
-        if (timeZone >= 0) {
-            if (timeZone >= 10) {
-                return "+" + timeZone + ":" + DOUBLE_ZERO;
-            } else {
-                return "+0" + timeZone + ":" + DOUBLE_ZERO;
-            }
-        } else {
-            if (timeZone <= -10) {
-                return timeZone + ":" + DOUBLE_ZERO;
-            } else {
-                return "-0" + Math.abs(timeZone) + ":" + DOUBLE_ZERO;
-            }
-        }
-    }
-
     /**
-     * <p>set.</p>
+     * <p>ofUnixTimeMillis</p>
+     * @param unixTimeMillis Milliseconds since 1970-01-01T00:00:00Z.
      *
-     * @param dateToSet a long.
      * @return a {@link org.n52.sos.importer.feeder.model.Timestamp} object.
      */
-    public Timestamp set(final long dateToSet) {
-        final Calendar cal = new GregorianCalendar();
-        if (timezone != Byte.MIN_VALUE) {
-            cal.setTimeZone(TimeZone.getTimeZone(TimeZone.getAvailableIDs((int) (timezone * MILLIS_PER_HOUR))[0]));
-        }
-        cal.setTimeInMillis(dateToSet);
-        year = (short) cal.get(Calendar.YEAR);
-        month = (byte) (cal.get(Calendar.MONTH) + 1);
-        day = (byte) cal.get(Calendar.DAY_OF_MONTH);
-        hour = (byte) cal.get(Calendar.HOUR_OF_DAY);
-        minute = (byte) cal.get(Calendar.MINUTE);
-        seconds = (byte) cal.get(Calendar.SECOND);
-        millis = cal.get(Calendar.MILLISECOND);
-        timezone = (byte) (cal.getTimeZone().getOffset(dateToSet) / MILLIS_PER_HOUR);
+    public Timestamp ofUnixTimeMillis(final long unixTimeMillis) {
+    	OffsetDateTime timestamp = OffsetDateTime.ofInstant(Instant.ofEpochMilli(unixTimeMillis),ZoneId.of("UTC"));
+        year = timestamp.getYear();
+        month = timestamp.getMonthValue();
+        day = timestamp.getDayOfMonth();
+        hour = timestamp.getHour();
+        minute = timestamp.getMinute();
+        seconds = timestamp.getSecond();
+        millis = timestamp.getNano()/1000;
+        timezone = timestamp.getOffset().getTotalSeconds()/3600;
         return this;
     }
 
     /**
      * <p>enrich.</p>
-     *
+     * @deprecated
      * @param timestampInformation the filename that might contain additional information
      *          for the {@link org.n52.sos.importer.feeder.model.Timestamp}
      * @param regExToExtractFileInfo a {@link java.lang.String} object.
@@ -183,34 +193,34 @@ public class Timestamp {
         final Pattern pattern = Pattern.compile(regExToExtractFileInfo);
         final Matcher matcher = pattern.matcher(timestampInformation);
         if (matcher.matches() && matcher.groupCount() == 1) {
-            final SimpleDateFormat sdf = new SimpleDateFormat(dateInfoPattern);
+            final DateTimeFormatter dtf = DateTimeFormatter.ofPattern(dateInfoPattern);
             final String dateInformation = matcher.group(1);
-            final GregorianCalendar cal = new GregorianCalendar();
-            cal.setTime(sdf.parse(dateInformation));
+
+            TemporalAccessor ta = dtf.parse(dateInformation);
 
             if (dateInfoPattern.contains("y")) {
-                setYear(Short.parseShort(Integer.toString(cal.get(GregorianCalendar.YEAR))));
+                setYear(ta.get(ChronoField.YEAR));
             }
             if (dateInfoPattern.contains("M")) {
-                setMonth(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.MONTH) + 1)));
+                setMonth(ta.get(ChronoField.MONTH_OF_YEAR));
             }
             if (dateInfoPattern.contains("d")) {
-                setDay(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.DAY_OF_MONTH))));
+                setDay(ta.get(ChronoField.DAY_OF_MONTH));
             }
             if (dateInfoPattern.contains("H")) {
-                setHour(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.HOUR_OF_DAY))));
+                setHour(ta.get(ChronoField.HOUR_OF_DAY));
             }
             if (dateInfoPattern.contains("m")) {
-                setMinute(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.MINUTE))));
+                setMinute(ta.get(ChronoField.MINUTE_OF_HOUR));
             }
             if (dateInfoPattern.contains("s")) {
-                setSeconds(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.SECOND))));
+                setSeconds(ta.get(ChronoField.SECOND_OF_MINUTE));
             }
             if (dateInfoPattern.contains("S")) {
-                setMillis(cal.get(GregorianCalendar.MILLISECOND));
+                setMillis(ta.get(ChronoField.MILLI_OF_SECOND));
             }
             if (dateInfoPattern.contains("z") || dateInfoPattern.contains("Z")) {
-                setTimezone(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.ZONE_OFFSET))));
+                setTimezone(ta.get(ChronoField.OFFSET_SECONDS)/3600);
             }
         }
         return this;
@@ -218,53 +228,52 @@ public class Timestamp {
 
     /**
      * <p>enrich.</p>
-     *
+     * @deprecated
      * @param lastModified long
-     * @param lastModifiedDelta -1, if it should be ignored, else &gt; 0.
+     * @param lastModifiedDeltaDays -1, if it should be ignored, else &gt; 0.
      * @return a {@link Timestamp} object.
      */
-    public Timestamp enrich(
+    public Timestamp adjustBy(
             final long lastModified,
-            final int lastModifiedDelta) {
-        final GregorianCalendar cal = new GregorianCalendar();
+            final int lastModifiedDeltaDays) {
         long lastModifiedTmp = lastModified;
-        if (lastModifiedDelta > 0) {
-            lastModifiedTmp = lastModified - (lastModifiedDelta * MILLIS_PER_DAY);
+        if (lastModifiedDeltaDays > 0) {
+            lastModifiedTmp = lastModified - (lastModifiedDeltaDays * MILLIS_PER_DAY);
         }
-        cal.setTime(new Date(lastModifiedTmp));
-        setYear(Short.parseShort(Integer.toString(cal.get(GregorianCalendar.YEAR))));
-        setMonth(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.MONTH) + 1)));
-        setDay(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.DAY_OF_MONTH))));
+        ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.ofEpochMilli(lastModifiedTmp), ZoneId.of("UTC"));
+        setYear(zdt.get(ChronoField.YEAR));
+        setMonth(zdt.get(ChronoField.MONTH_OF_YEAR));
+        setDay(zdt.get(ChronoField.DAY_OF_MONTH));
         return this;
     }
 
     /**
-     * <p>enrich.</p>
+     * <p>enrich with values from another timestamp.</p>
      *
      * @param other a {@link Timestamp} object.
      * @return a {@link Timestamp} object.
      */
     public Timestamp enrich(final Timestamp other) {
         if (other != null) {
-            if (other.getYear() > Short.MIN_VALUE) {
+            if (other.getYear() > Integer.MIN_VALUE) {
                 setYear(other.getYear());
             }
-            if (other.getMonth() > Byte.MIN_VALUE) {
+            if (other.getMonth() > Integer.MIN_VALUE) {
                 setMonth(other.getMonth());
             }
-            if (other.getDay() > Byte.MIN_VALUE) {
+            if (other.getDay() > Integer.MIN_VALUE) {
                 setDay(other.getDay());
             }
-            if (other.getHour() > Byte.MIN_VALUE) {
+            if (other.getHour() > Integer.MIN_VALUE) {
                 setHour(other.getHour());
             }
-            if (other.getMinute() > Byte.MIN_VALUE) {
+            if (other.getMinute() > Integer.MIN_VALUE) {
                 setMinute(other.getMinute());
             }
-            if (other.getSeconds() > Byte.MIN_VALUE) {
+            if (other.getSeconds() > Integer.MIN_VALUE) {
                 setSeconds(other.getSeconds());
             }
-            if (other.getTimezone() > Byte.MIN_VALUE) {
+            if (other.getTimezone() > Integer.MIN_VALUE) {
                 setTimezone(other.getTimezone());
             }
             if (other.getMillis() > Integer.MIN_VALUE) {
@@ -275,108 +284,121 @@ public class Timestamp {
     }
 
     /**
-     * <p>toDate.</p>
-     *
-     * @return a {@link java.util.Date} object.
+     * @return Instant of the current {@link Timestamp} object.
      */
-    protected Date toDate() {
-        final String datePattern = getDatePattern();
-        try {
-            return new SimpleDateFormat(datePattern).parse(toString());
-        } catch (final ParseException e) {
-            throw new RuntimeException("Could not execute toDate()", e);
-        }
+    protected Instant toInstant() {
+    	DateTimeFormatter dtf = DateTimeFormatter.ofPattern(getDatePattern());
+    	String iso8601String = toISO8601String();
+    	try {
+			return dtf.parse(iso8601String, ZonedDateTime::from).toInstant();
+    	} catch (DateTimeException e) {}
+    	try {
+    		return dtf.parse(iso8601String, OffsetDateTime::from).toInstant();
+		} catch (DateTimeException e) {}
+    	try {
+    		return dtf.parse(iso8601String, LocalDateTime::from).toInstant(ZoneOffset.of("UTC"));
+    	} catch (DateTimeException e) {}
+    	try {
+    		return Instant.ofEpochMilli(dtf.parse(iso8601String, LocalDate::from).toEpochDay()*MILLIS_PER_DAY);
+    	} catch (DateTimeException e) {}
+    	return Instant.ofEpochMilli(0);
     }
 
     private String getDatePattern() {
-        // "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+        // "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
         final StringBuffer ts = new StringBuffer(31);
-        if (year != Short.MIN_VALUE) {
+        if (year != Integer.MIN_VALUE) {
             ts.append("yyyy");
-            if (month != Byte.MIN_VALUE) {
+            if (month != Integer.MIN_VALUE) {
                 ts.append("-");
             }
         }
-        if (month != Byte.MIN_VALUE) {
+        if (month != Integer.MIN_VALUE) {
             ts.append("MM");
-            if (day != Byte.MIN_VALUE) {
+            if (day != Integer.MIN_VALUE) {
                 ts.append("-");
             }
         }
-        if (day != Byte.MIN_VALUE) {
+        if (day != Integer.MIN_VALUE) {
             ts.append("dd");
         }
-        if ((year != Short.MIN_VALUE || month != Byte.MIN_VALUE || day != Byte.MIN_VALUE)
-                && (hour != Byte.MIN_VALUE || minute != Byte.MIN_VALUE || seconds != Byte.MIN_VALUE)) {
+        if ((year != Integer.MIN_VALUE || month != Integer.MIN_VALUE || day != Integer.MIN_VALUE)
+                && (hour != Integer.MIN_VALUE || minute != Integer.MIN_VALUE || seconds != Integer.MIN_VALUE)) {
             ts.append("'T'");
         }
-        if (hour != Byte.MIN_VALUE) {
+        if (hour != Integer.MIN_VALUE) {
             ts.append("HH");
-            if (minute != Byte.MIN_VALUE) {
+            if (minute != Integer.MIN_VALUE) {
                 ts.append(":");
             }
         }
-        if (minute != Byte.MIN_VALUE) {
+        if (minute != Integer.MIN_VALUE) {
             ts.append(MM);
-        } else if (hour != Byte.MIN_VALUE) {
+        } else if (hour != Integer.MIN_VALUE) {
             ts.append(MM);
         }
-        if (seconds != Byte.MIN_VALUE) {
+        if (seconds != Integer.MIN_VALUE) {
             ts.append(SS);
-        } else if (minute != Byte.MIN_VALUE && hour != Byte.MIN_VALUE) {
+        } else if (minute != Integer.MIN_VALUE && hour != Integer.MIN_VALUE) {
             ts.append(SS);
         }
         if (millis != Integer.MIN_VALUE) {
             ts.append(".SSS");
         }
-        if (timezone != Byte.MIN_VALUE &&
-                (hour != Byte.MIN_VALUE || minute != Byte.MIN_VALUE || seconds != Byte.MIN_VALUE)) {
-            ts.append("X");
+        if (timezone != Integer.MIN_VALUE &&
+                (hour != Integer.MIN_VALUE || minute != Integer.MIN_VALUE || seconds != Integer.MIN_VALUE)) {
+            ts.append("XXX");
         }
         final String datePattern = ts.toString();
         if (datePattern.isEmpty()) {
-            return "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+            return "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
         }
         return datePattern;
     }
 
     /**
      * <p>after.</p>
-     *
+     * @deprecated
      * @param timeStamp a {@link org.n52.sos.importer.feeder.model.Timestamp} object.
      * @return a boolean.
      */
-    public boolean after(final Timestamp timeStamp) {
+    public boolean isAfter(final Timestamp timeStamp) {
         if (timeStamp == null) {
             throw new IllegalArgumentException(PARAMETER_TIME_STAMP_IS_MANDATORY);
         }
-        return toDate().after(timeStamp.toDate());
+        return toInstant().isAfter(timeStamp.toInstant());
     }
 
     /**
      * <p>before.</p>
-     *
+     * @deprecated
      * @param timeStamp a {@link org.n52.sos.importer.feeder.model.Timestamp} object.
      * @return a boolean.
      */
-    public boolean before(final Timestamp timeStamp) {
+    public boolean isBefore(final Timestamp timeStamp) {
         if (timeStamp == null) {
             throw new IllegalArgumentException(PARAMETER_TIME_STAMP_IS_MANDATORY);
         }
-        return toDate().before(timeStamp.toDate());
+        return toInstant().isBefore(timeStamp.toInstant());
     }
 
     /**
      * <p>applyDayDelta.</p>
-     *
+     * @deprecated
      * @param daysToAdd a int.
      * @return a {@link Timestamp} object.
      */
     public Timestamp applyDayDelta(final int daysToAdd) {
-        final Timestamp tmp = new Timestamp().set(toDate().getTime() + (daysToAdd * MILLIS_PER_DAY));
-        setYear(tmp.getYear());
-        setMonth(tmp.getMonth());
-        setDay(tmp.getDay());
+        TemporalAccessor ta = DateTimeFormatter.ofPattern(getDatePattern()).parse(toISO8601String());
+        if (ta.isSupported(ChronoField.YEAR) &&
+        		ta.isSupported(ChronoField.MONTH_OF_YEAR) &&
+        		ta.isSupported(ChronoField.DAY_OF_MONTH)) {
+        	LocalDate ld = LocalDate.of(ta.get(ChronoField.YEAR), ta.get(ChronoField.MONTH_OF_YEAR), ta.get(ChronoField.DAY_OF_MONTH));
+        	ld = ld.plusDays(daysToAdd);
+        	setYear(ld.getYear());
+        	setMonth(ld.getMonthValue());
+        	setDay(ld.getDayOfMonth());
+    	}
         return this;
     }
 
@@ -385,7 +407,7 @@ public class Timestamp {
      *
      * @param year a short.
      */
-    public void setYear(final short year) {
+    public void setYear(final int year) {
         this.year = year;
     }
 
@@ -394,7 +416,7 @@ public class Timestamp {
      *
      * @param month a byte.
      */
-    public void setMonth(final byte month) {
+    public void setMonth(final int month) {
         this.month = month;
     }
 
@@ -403,7 +425,7 @@ public class Timestamp {
      *
      * @param day a byte.
      */
-    public void setDay(final byte day) {
+    public void setDay(final int day) {
         this.day = day;
     }
 
@@ -412,7 +434,7 @@ public class Timestamp {
      *
      * @param hour a byte.
      */
-    public void setHour(final byte hour) {
+    public void setHour(final int hour) {
         this.hour = hour;
     }
 
@@ -421,7 +443,7 @@ public class Timestamp {
      *
      * @param minute a byte.
      */
-    public void setMinute(final byte minute) {
+    public void setMinute(final int minute) {
         this.minute = minute;
     }
 
@@ -430,7 +452,7 @@ public class Timestamp {
      *
      * @param seconds a byte.
      */
-    public void setSeconds(final byte seconds) {
+    public void setSeconds(final int seconds) {
         this.seconds = seconds;
     }
 
@@ -439,7 +461,7 @@ public class Timestamp {
      *
      * @param timezone a byte.
      */
-    public void setTimezone(final byte timezone) {
+    public void setTimezone(final int timezone) {
         this.timezone = timezone;
     }
 
@@ -448,7 +470,7 @@ public class Timestamp {
      *
      * @return a short.
      */
-    public short getYear() {
+    public int getYear() {
         return year;
     }
 
@@ -457,7 +479,7 @@ public class Timestamp {
      *
      * @return a byte.
      */
-    public byte getMonth() {
+    public int getMonth() {
         return month;
     }
 
@@ -466,7 +488,7 @@ public class Timestamp {
      *
      * @return a byte.
      */
-    public byte getDay() {
+    public int getDay() {
         return day;
     }
 
@@ -475,7 +497,7 @@ public class Timestamp {
      *
      * @return a byte.
      */
-    public byte getHour() {
+    public int getHour() {
         return hour;
     }
 
@@ -484,7 +506,7 @@ public class Timestamp {
      *
      * @return a byte.
      */
-    public byte getMinute() {
+    public int getMinute() {
         return minute;
     }
 
@@ -493,7 +515,7 @@ public class Timestamp {
      *
      * @return a byte.
      */
-    public byte getSeconds() {
+    public int getSeconds() {
         return seconds;
     }
 
@@ -502,7 +524,7 @@ public class Timestamp {
      *
      * @return a byte.
      */
-    public byte getTimezone() {
+    public int getTimezone() {
         return timezone;
     }
 

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
@@ -28,7 +28,6 @@
  */
 package org.n52.sos.importer.feeder.model;
 
-import java.text.DateFormat;
 import java.text.ParseException;
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -41,20 +40,12 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
-import java.util.Date;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
  * <p>Timestamp class.</p>
- *
- * TODO switch to Joda time or java 8 to get time zone problems fixed
- * Notes for implementation
- * - getter => use the java.time equivalents
- * - setter => use java.time.obj.with(...) -> returning objects
- * - differ between timezone offset and timezone id based timestamps
- *  ZonedDateTime OffsetDateTime
  *
  * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
  * @version $Id: $Id
@@ -79,7 +70,6 @@ public class Timestamp {
 
     /** {@inheritDoc} */
     @Override
-    @Deprecated
     public String toString() {
     	return toISO8601String();
     }
@@ -358,7 +348,6 @@ public class Timestamp {
 
     /**
      * <p>after.</p>
-     * @deprecated
      * @param timeStamp a {@link org.n52.sos.importer.feeder.model.Timestamp} object.
      * @return a boolean.
      */
@@ -371,7 +360,6 @@ public class Timestamp {
 
     /**
      * <p>before.</p>
-     * @deprecated
      * @param timeStamp a {@link org.n52.sos.importer.feeder.model.Timestamp} object.
      * @return a boolean.
      */
@@ -384,7 +372,6 @@ public class Timestamp {
 
     /**
      * <p>applyDayDelta.</p>
-     * @deprecated
      * @param daysToAdd a int.
      * @return a {@link Timestamp} object.
      */

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
@@ -68,7 +68,7 @@ public class Timestamp {
     @Override
     public String toString() {
         // yyyy-MM-ddTHH:mm:ss+hh:mm => 31 chars
-        final StringBuffer ts = new StringBuffer(31);
+        final StringBuilder ts = new StringBuilder(31);
         if (year != Short.MIN_VALUE) {
             ts.append(year);
             if (month != Byte.MIN_VALUE) {
@@ -95,7 +95,7 @@ public class Timestamp {
             }
         }
         if (minute != Byte.MIN_VALUE) {
-            ts.append((minute < 10 ? SINGLE_ZERO + minute : minute) + ":");
+            ts.append(minute < 10 ? SINGLE_ZERO + minute : minute).append(":");
         } else if (hour != Byte.MIN_VALUE) {
             ts.append(DOUBLE_ZERO);
             ts.append(":");
@@ -106,7 +106,7 @@ public class Timestamp {
             ts.append(DOUBLE_ZERO);
         }
         if (millis != Integer.MIN_VALUE) {
-            ts.append("." + (millis < 10 ? DOUBLE_ZERO + millis : (millis < 100 ? SINGLE_ZERO + millis : millis)));
+            ts.append(".").append(millis < 10 ? DOUBLE_ZERO + millis : (millis < 100 ? SINGLE_ZERO + millis : millis));
         }
         if (timezone != Byte.MIN_VALUE &&
                 (hour != Byte.MIN_VALUE || minute != Byte.MIN_VALUE || seconds != Byte.MIN_VALUE)) {
@@ -188,28 +188,28 @@ public class Timestamp {
             final GregorianCalendar cal = new GregorianCalendar();
             cal.setTime(sdf.parse(dateInformation));
 
-            if (dateInfoPattern.indexOf("y") > -1) {
+            if (dateInfoPattern.contains("y")) {
                 setYear(Short.parseShort(Integer.toString(cal.get(GregorianCalendar.YEAR))));
             }
-            if (dateInfoPattern.indexOf("M") > -1) {
+            if (dateInfoPattern.contains("M")) {
                 setMonth(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.MONTH) + 1)));
             }
-            if (dateInfoPattern.indexOf("d") > -1) {
+            if (dateInfoPattern.contains("d")) {
                 setDay(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.DAY_OF_MONTH))));
             }
-            if (dateInfoPattern.indexOf("H") > -1) {
+            if (dateInfoPattern.contains("H")) {
                 setHour(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.HOUR_OF_DAY))));
             }
-            if (dateInfoPattern.indexOf("m") > -1) {
+            if (dateInfoPattern.contains("m")) {
                 setMinute(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.MINUTE))));
             }
-            if (dateInfoPattern.indexOf("s") > -1) {
+            if (dateInfoPattern.contains("s")) {
                 setSeconds(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.SECOND))));
             }
-            if (dateInfoPattern.indexOf("S") > -1) {
+            if (dateInfoPattern.contains("S")) {
                 setMillis(cal.get(GregorianCalendar.MILLISECOND));
             }
-            if (dateInfoPattern.indexOf("z") > -1 || dateInfoPattern.indexOf("Z") > -1) {
+            if (dateInfoPattern.contains("z") || dateInfoPattern.contains("Z")) {
                 setTimezone(Byte.parseByte(Integer.toString(cal.get(GregorianCalendar.ZONE_OFFSET))));
             }
         }

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/model/Timestamp.java
@@ -71,7 +71,7 @@ public class Timestamp {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-    	return toISO8601String();
+        return toISO8601String();
     }
 
     public String toISO8601String() {
@@ -118,17 +118,17 @@ public class Timestamp {
         }
         if (timezone != Integer.MIN_VALUE &&
                 (hour != Integer.MIN_VALUE || minute != Integer.MIN_VALUE || seconds != Integer.MIN_VALUE)) {
-        	if (timezone >= 0) {
+            if (timezone >= 0) {
                 if (timezone >= 10) {
                     ts.append("+").append(timezone).append(":").append(DOUBLE_ZERO);
                 } else {
-                	ts.append("+0").append(timezone).append(":").append(DOUBLE_ZERO);
+                    ts.append("+0").append(timezone).append(":").append(DOUBLE_ZERO);
                 }
             } else {
                 if (timezone <= -10) {
-                	ts.append(timezone).append(":").append(DOUBLE_ZERO);
+                    ts.append(timezone).append(":").append(DOUBLE_ZERO);
                 } else {
-                	ts.append("-0").append(Math.abs(timezone)).append(":").append(DOUBLE_ZERO);
+                    ts.append("-0").append(Math.abs(timezone)).append(":").append(DOUBLE_ZERO);
                 }
             }
         }
@@ -142,7 +142,7 @@ public class Timestamp {
      * @return a {@link org.n52.sos.importer.feeder.model.Timestamp} object.
      */
     public Timestamp ofUnixTimeMillis(final long unixTimeMillis) {
-    	OffsetDateTime timestamp = OffsetDateTime.ofInstant(Instant.ofEpochMilli(unixTimeMillis),ZoneId.of("UTC"));
+        OffsetDateTime timestamp = OffsetDateTime.ofInstant(Instant.ofEpochMilli(unixTimeMillis),ZoneId.of("UTC"));
         year = timestamp.getYear();
         month = timestamp.getMonthValue();
         day = timestamp.getDayOfMonth();
@@ -209,8 +209,8 @@ public class Timestamp {
             if (dateInfoPattern.contains("S")) {
                 setMillis(ta.get(ChronoField.MILLI_OF_SECOND));
             }
-            if (dateInfoPattern.contains("z") || dateInfoPattern.contains("Z")) {
-                setTimezone(ta.get(ChronoField.OFFSET_SECONDS)/3600);
+            if (dateInfoPattern.contains("Z")) {
+                setTimezone(ta.get(ChronoField.OFFSET_SECONDS) / 3600);
             }
         }
         return this;
@@ -277,21 +277,21 @@ public class Timestamp {
      * @return Instant of the current {@link Timestamp} object.
      */
     protected Instant toInstant() {
-    	DateTimeFormatter dtf = DateTimeFormatter.ofPattern(getDatePattern());
-    	String iso8601String = toISO8601String();
-    	try {
-			return dtf.parse(iso8601String, ZonedDateTime::from).toInstant();
-    	} catch (DateTimeException e) {}
-    	try {
-    		return dtf.parse(iso8601String, OffsetDateTime::from).toInstant();
-		} catch (DateTimeException e) {}
-    	try {
-    		return dtf.parse(iso8601String, LocalDateTime::from).toInstant(ZoneOffset.of("UTC"));
-    	} catch (DateTimeException e) {}
-    	try {
-    		return Instant.ofEpochMilli(dtf.parse(iso8601String, LocalDate::from).toEpochDay()*MILLIS_PER_DAY);
-    	} catch (DateTimeException e) {}
-    	return Instant.ofEpochMilli(0);
+        DateTimeFormatter dtf = DateTimeFormatter.ofPattern(getDatePattern());
+        String iso8601String = toISO8601String();
+        try {
+            return dtf.parse(iso8601String, ZonedDateTime::from).toInstant();
+        } catch (DateTimeException e) {}
+        try {
+            return dtf.parse(iso8601String, OffsetDateTime::from).toInstant();
+        } catch (DateTimeException e) {}
+        try {
+            return dtf.parse(iso8601String, LocalDateTime::from).toInstant(ZoneOffset.of("UTC"));
+        } catch (DateTimeException e) {}
+        try {
+            return Instant.ofEpochMilli(dtf.parse(iso8601String, LocalDate::from).toEpochDay()*MILLIS_PER_DAY);
+        } catch (DateTimeException e) {}
+        return Instant.ofEpochMilli(0);
     }
 
     private String getDatePattern() {
@@ -378,14 +378,14 @@ public class Timestamp {
     public Timestamp applyDayDelta(final int daysToAdd) {
         TemporalAccessor ta = DateTimeFormatter.ofPattern(getDatePattern()).parse(toISO8601String());
         if (ta.isSupported(ChronoField.YEAR) &&
-        		ta.isSupported(ChronoField.MONTH_OF_YEAR) &&
-        		ta.isSupported(ChronoField.DAY_OF_MONTH)) {
-        	LocalDate ld = LocalDate.of(ta.get(ChronoField.YEAR), ta.get(ChronoField.MONTH_OF_YEAR), ta.get(ChronoField.DAY_OF_MONTH));
-        	ld = ld.plusDays(daysToAdd);
-        	setYear(ld.getYear());
-        	setMonth(ld.getMonthValue());
-        	setDay(ld.getDayOfMonth());
-    	}
+                ta.isSupported(ChronoField.MONTH_OF_YEAR) &&
+                ta.isSupported(ChronoField.DAY_OF_MONTH)) {
+            LocalDate ld = LocalDate.of(ta.get(ChronoField.YEAR), ta.get(ChronoField.MONTH_OF_YEAR), ta.get(ChronoField.DAY_OF_MONTH));
+            ld = ld.plusDays(daysToAdd);
+            setYear(ld.getYear());
+            setMonth(ld.getMonthValue());
+            setDay(ld.getDayOfMonth());
+        }
         return this;
     }
 

--- a/feeder/src/main/java/org/n52/sos/importer/feeder/util/DescriptionBuilder.java
+++ b/feeder/src/main/java/org/n52/sos/importer/feeder/util/DescriptionBuilder.java
@@ -157,7 +157,7 @@ public class DescriptionBuilder {
         builder.setClassifierIntendedApplication(intendedApplication.substring(0, intendedApplication.length() - 2));
 
         // add validTime starting from now
-        builder.setValidTime(new Timestamp().set(System.currentTimeMillis()).toString(), "unknown");
+        builder.setValidTime(new Timestamp().ofUnixTimeMillis(System.currentTimeMillis()).toString(), "unknown");
 
         return builder.buildSensorDescription();
     }

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue66ParseUnixtime.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue66ParseUnixtime.java
@@ -62,13 +62,13 @@ public class TestIssue66ParseUnixtime {
 
         // then
         Assert.assertThat(timeStamp, Is.is(Matchers.notNullValue()));
-        Assert.assertThat(timeStamp.getYear(), Is.is((short) 2016));
-        Assert.assertThat(timeStamp.getMonth(), Is.is((byte) 6));
-        Assert.assertThat(timeStamp.getDay(), Is.is((byte) 9));
-        Assert.assertThat(timeStamp.getHour(), Is.is((byte) 10));
-        Assert.assertThat(timeStamp.getMinute(), Is.is((byte) 29));
-        Assert.assertThat(timeStamp.getSeconds(), Is.is((byte) 40));
-        Assert.assertThat(timeStamp.getTimezone(), Is.is((byte) 0));
+        Assert.assertThat(timeStamp.getYear(), Is.is(2016));
+        Assert.assertThat(timeStamp.getMonth(), Is.is(6));
+        Assert.assertThat(timeStamp.getDay(), Is.is(9));
+        Assert.assertThat(timeStamp.getHour(), Is.is(10));
+        Assert.assertThat(timeStamp.getMinute(), Is.is(29));
+        Assert.assertThat(timeStamp.getSeconds(), Is.is(40));
+        Assert.assertThat(timeStamp.getTimezone(), Is.is(0));
     }
 
 }

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue78NullPointerExceptionWhenParsingDateTime.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue78NullPointerExceptionWhenParsingDateTime.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2011-2016 52°North Initiative for Geospatial Open Source
+ * Software GmbH
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ *
+ * If the program is linked with libraries which are licensed under one of
+ * the following licenses, the combination of the program with the linked
+ * library is not considered a "derivative work" of the program:
+ *
+ *     - Apache License, version 2.0
+ *     - Apache Software License, version 1.0
+ *     - GNU Lesser General Public License, version 3
+ *     - Mozilla Public License, versions 1.0, 1.1 and 2.0
+ *     - Common Development and Distribution License (CDDL), version 1.0
+ *
+ * Therefore the distribution of the program linked with libraries licensed
+ * under the aforementioned licenses, is permitted by the copyright holders
+ * if the distribution is compliant with both the GNU General Public
+ * License version 2 and the aforementioned licenses.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+ * Public License for more details.
+ */
+package org.n52.sos.importer.feeder;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+import org.apache.xmlbeans.XmlException;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.Is;
+import org.junit.Assert;
+import org.junit.Test;
+import org.n52.sos.importer.feeder.model.Timestamp;
+
+/**
+ * Test for Issue #66: Parsing Uninx time fails
+ *
+ * https://github.com/52North/sos-importer/issues/66
+ *
+ * @author <a href="mailto:e.h.juerrens@52north.org">Eike Hinderk J&uuml;rrens</a>
+ *
+ */
+public class TestIssue78NullPointerExceptionWhenParsingDateTime {
+
+    @Test
+    public void shouldParseTimestampWithConfigWithoutTimezone() throws XmlException, IOException, ParseException {
+        // given
+        Configuration configuration = new Configuration("src/test/resources/issue-078/data_config_without-zone.xml");
+        DataFile dataFile = new DataFile(configuration, null);
+        int mVColumnId = 2;
+        // Thu, 09 Jun 2016 10:29:40 GMT
+        String[] values = {"2017-04-13T08:27:28","20.80","39.20"};
+
+        // when
+        final Timestamp timeStamp = dataFile.getTimeStamp(mVColumnId, values);
+
+        // then
+        Assert.assertThat(timeStamp, Is.is(Matchers.notNullValue()));
+        Assert.assertThat(timeStamp.getYear(), Is.is((short) 2017));
+        Assert.assertThat(timeStamp.getMonth(), Is.is((byte) 4));
+        Assert.assertThat(timeStamp.getDay(), Is.is((byte) 13));
+        Assert.assertThat(timeStamp.getHour(), Is.is((byte) 8));
+        Assert.assertThat(timeStamp.getMinute(), Is.is((byte) 27));
+        Assert.assertThat(timeStamp.getSeconds(), Is.is((byte) 28));
+        Assert.assertThat(timeStamp.getTimezone(), Is.is((byte) 0));
+    }
+
+    @Test
+    public void shouldParseTimestampWithConfigWithTimezoneZ() throws XmlException, IOException, ParseException {
+        // given
+        Configuration configuration = new Configuration("src/test/resources/issue-078/data_config_with-zone-Z.xml");
+        DataFile dataFile = new DataFile(configuration, null);
+        int mVColumnId = 2;
+        // Thu, 09 Jun 2016 10:29:40 GMT
+        String[] values = {"2017-04-13T08:27:28Z","20.80","39.20"};
+
+        // when
+        final Timestamp timeStamp = dataFile.getTimeStamp(mVColumnId, values);
+
+        // then
+        Assert.assertThat(timeStamp, Is.is(Matchers.notNullValue()));
+        Assert.assertThat(timeStamp.getYear(), Is.is((short) 2017));
+        Assert.assertThat(timeStamp.getMonth(), Is.is((byte) 4));
+        Assert.assertThat(timeStamp.getDay(), Is.is((byte) 13));
+        Assert.assertThat(timeStamp.getHour(), Is.is((byte) 8));
+        Assert.assertThat(timeStamp.getMinute(), Is.is((byte) 27));
+        Assert.assertThat(timeStamp.getSeconds(), Is.is((byte) 28));
+        Assert.assertThat(timeStamp.getTimezone(), Is.is((byte) 0));
+    }
+
+}

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue78NullPointerExceptionWhenParsingDateTime.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue78NullPointerExceptionWhenParsingDateTime.java
@@ -30,16 +30,11 @@ package org.n52.sos.importer.feeder;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.TimeZone;
 
 import org.apache.xmlbeans.XmlException;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue78NullPointerExceptionWhenParsingDateTime.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/TestIssue78NullPointerExceptionWhenParsingDateTime.java
@@ -35,6 +35,7 @@ import org.apache.xmlbeans.XmlException;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.n52.sos.importer.feeder.model.Timestamp;
 
@@ -62,13 +63,13 @@ public class TestIssue78NullPointerExceptionWhenParsingDateTime {
 
         // then
         Assert.assertThat(timeStamp, Is.is(Matchers.notNullValue()));
-        Assert.assertThat(timeStamp.getYear(), Is.is((short) 2017));
-        Assert.assertThat(timeStamp.getMonth(), Is.is((byte) 4));
-        Assert.assertThat(timeStamp.getDay(), Is.is((byte) 13));
-        Assert.assertThat(timeStamp.getHour(), Is.is((byte) 8));
-        Assert.assertThat(timeStamp.getMinute(), Is.is((byte) 27));
-        Assert.assertThat(timeStamp.getSeconds(), Is.is((byte) 28));
-        Assert.assertThat(timeStamp.getTimezone(), Is.is((byte) 0));
+        Assert.assertThat(timeStamp.getYear(), Is.is(2017));
+        Assert.assertThat(timeStamp.getMonth(), Is.is(4));
+        Assert.assertThat(timeStamp.getDay(), Is.is( 13));
+        Assert.assertThat(timeStamp.getHour(), Is.is( 8));
+        Assert.assertThat(timeStamp.getMinute(), Is.is(27));
+        Assert.assertThat(timeStamp.getSeconds(), Is.is(28));
+        Assert.assertThat(timeStamp.getTimezone(), Is.is(0));
     }
 
     @Test
@@ -85,13 +86,37 @@ public class TestIssue78NullPointerExceptionWhenParsingDateTime {
 
         // then
         Assert.assertThat(timeStamp, Is.is(Matchers.notNullValue()));
+        Assert.assertThat(timeStamp.getYear(), Is.is( 2017));
+        Assert.assertThat(timeStamp.getMonth(), Is.is(4));
+        Assert.assertThat(timeStamp.getDay(), Is.is(13));
+        Assert.assertThat(timeStamp.getHour(), Is.is(8));
+        Assert.assertThat(timeStamp.getMinute(), Is.is(27));
+        Assert.assertThat(timeStamp.getSeconds(), Is.is(28));
+        Assert.assertThat(timeStamp.getTimezone(), Is.is(0));
+    }
+
+    @Test
+    @Ignore
+    public void shouldParseTimestampWithConfigWithTimezoneText() throws XmlException, IOException, ParseException {
+        // given
+        Configuration configuration = new Configuration("src/test/resources/issue-078/data_config_with-zone-z.xml");
+        DataFile dataFile = new DataFile(configuration, null);
+        int mVColumnId = 2;
+        // Thu, 09 Jun 2016 10:29:40 GMT
+        String[] values = {"2017-04-13T08:27:28MESZ","20.80","39.20"};
+
+        // when
+        final Timestamp timeStamp = dataFile.getTimeStamp(mVColumnId, values);
+
+        // then
+        Assert.assertThat(timeStamp, Is.is(Matchers.notNullValue()));
         Assert.assertThat(timeStamp.getYear(), Is.is((short) 2017));
         Assert.assertThat(timeStamp.getMonth(), Is.is((byte) 4));
         Assert.assertThat(timeStamp.getDay(), Is.is((byte) 13));
         Assert.assertThat(timeStamp.getHour(), Is.is((byte) 8));
         Assert.assertThat(timeStamp.getMinute(), Is.is((byte) 27));
         Assert.assertThat(timeStamp.getSeconds(), Is.is((byte) 28));
-        Assert.assertThat(timeStamp.getTimezone(), Is.is((byte) 0));
+        Assert.assertThat(timeStamp.getTimezone(), Is.is((byte) 2));
     }
 
 }

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/model/TimeSeriesRepositoryTest.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/model/TimeSeriesRepositoryTest.java
@@ -48,7 +48,7 @@ public class TimeSeriesRepositoryTest {
         Sensor sensor = new Sensor("test-sensor-1-name", sensorURI);
         FeatureOfInterest foi = new FeatureOfInterest("foi-name", "foi-uri", null);
         Object value = 1;
-        Timestamp timeStamp = new Timestamp().set(System.currentTimeMillis());
+        Timestamp timeStamp = new Timestamp().ofUnixTimeMillis(System.currentTimeMillis());
         Offering off = new Offering("offering-name", "offering-uri");
         String mvType = "mv-type";
         InsertObservation io =

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/model/TimestampTest.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/model/TimestampTest.java
@@ -29,13 +29,14 @@
 package org.n52.sos.importer.feeder.model;
 
 import java.text.ParseException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.TimeZone;
 
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class TimestampTest {
@@ -87,7 +88,7 @@ public class TimestampTest {
         final String hoursString = String.format(DECIMAL, hours);
         // why minutes+1?
         final int minutesTime = Integer.parseInt(minutesString) + 1;
-        final String timeMinutesString = minutesTime < 10 ? "0" + minutesTime : Integer.toString(minutesTime);
+        final String timeMinutesString = String.format(DECIMAL, minutesTime);
         final String offsetInHoursString = String.format(DECIMAL, Math.abs(offsetInHours));
         final String asExpected = String.format("1970-01-01T%s:%s:00.000%s%s:%s",
                 hoursString,
@@ -97,19 +98,21 @@ public class TimestampTest {
                 minutesString);
 
         // when
-        timestamp.set(UTC_12_01);
+        timestamp.ofUnixTimeMillis(UTC_12_01);
+        ZonedDateTime a = ZonedDateTime.parse(timestamp.toISO8601String());
+        ZonedDateTime b = ZonedDateTime.parse(asExpected);
 
         // then
-        Assert.assertThat(timestamp.toString(), CoreMatchers.is(asExpected));
+        Assert.assertThat(a.isEqual(b), CoreMatchers.is(true));
     }
 
     @Test
-    public void shouldCreateDateFromTimestamp() {
+    public void shouldCreateInstantFromTimestamp() {
         final long time = UTC_12_01;
-        final Date dateFromTimestamp = timestamp.set(time).toDate();
-        final Date dateFromSystem = new Date(time);
-        Assert.assertThat(dateFromTimestamp.compareTo(dateFromSystem), CoreMatchers.is(0));
+        final Instant instantFromTimestamp = timestamp.ofUnixTimeMillis(time).toInstant();
+        final Instant instantFromSystem = Instant.ofEpochMilli(time);
 
+        Assert.assertThat(instantFromTimestamp.compareTo(instantFromSystem), CoreMatchers.is(0));
     }
 
     @Test
@@ -120,7 +123,7 @@ public class TimestampTest {
 
         ts.enrich(fileName, "test-sensor_(\\d{8})\\.csv", "yyyyMMdd");
 
-        Assert.assertThat(ts.toString(), CoreMatchers.is("2014-06-15"));
+        Assert.assertThat(ts.toISO8601String(), CoreMatchers.is("2014-06-15"));
     }
 
     @Test
@@ -128,34 +131,34 @@ public class TimestampTest {
             throws ParseException {
         Timestamp ts = new Timestamp();
         ts.enrich(null, null, null);
-        Assert.assertThat(ts.toString(), CoreMatchers.is(""));
+        Assert.assertThat(ts.toISO8601String(), CoreMatchers.is(""));
 
         ts = new Timestamp();
         ts.enrich("", null, null);
-        Assert.assertThat(ts.toString(), CoreMatchers.is(""));
+        Assert.assertThat(ts.toISO8601String(), CoreMatchers.is(""));
 
         ts = new Timestamp();
         ts.enrich("-", null, null);
-        Assert.assertThat(ts.toString(), CoreMatchers.is(""));
+        Assert.assertThat(ts.toISO8601String(), CoreMatchers.is(""));
 
         ts = new Timestamp();
         ts.enrich("-", "", null);
-        Assert.assertThat(ts.toString(), CoreMatchers.is(""));
+        Assert.assertThat(ts.toISO8601String(), CoreMatchers.is(""));
 
         ts = new Timestamp();
         ts.enrich("-", "-", null);
-        Assert.assertThat(ts.toString(), CoreMatchers.is(""));
+        Assert.assertThat(ts.toISO8601String(), CoreMatchers.is(""));
 
         ts = new Timestamp();
         ts.enrich("-", "-", "");
-        Assert.assertThat(ts.toString(), CoreMatchers.is(""));
+        Assert.assertThat(ts.toISO8601String(), CoreMatchers.is(""));
     }
 
     @Test
     public final void shouldEnrichWithLastModificationDate() {
         final long lastModified = UTC_12_01;
-        timestamp.enrich(lastModified, -1);
-        final Timestamp expected = new Timestamp().set(lastModified);
+        timestamp.adjustBy(lastModified, -1);
+        final Timestamp expected = new Timestamp().ofUnixTimeMillis(lastModified);
         Assert.assertThat(timestamp.getYear(), CoreMatchers.is(expected.getYear()));
         Assert.assertThat(timestamp.getMonth(), CoreMatchers.is(expected.getMonth()));
         Assert.assertThat(timestamp.getDay(), CoreMatchers.is(expected.getDay()));
@@ -165,9 +168,9 @@ public class TimestampTest {
     public final void shouldEnrichWithLastModificationDateWithLastModifiedDayDelta() {
         final long lastModified = UTC_12_01;
         final int lastModifiedDelta = 2;
-        timestamp.enrich(lastModified, lastModifiedDelta);
+        timestamp.adjustBy(lastModified, lastModifiedDelta);
         final long expectedMillis = lastModified - (lastModifiedDelta * MILLIS_PER_DAY);
-        final Timestamp expected = new Timestamp().set(expectedMillis);
+        final Timestamp expected = new Timestamp().ofUnixTimeMillis(expectedMillis);
         Assert.assertThat(timestamp.getYear(), CoreMatchers.is(expected.getYear()));
         Assert.assertThat(timestamp.getMonth(), CoreMatchers.is(expected.getMonth()));
         Assert.assertThat(timestamp.getDay(), CoreMatchers.is(expected.getDay()));
@@ -178,8 +181,8 @@ public class TimestampTest {
         final long lastModified = 0;
         final int lastModifiedDelta = 2;
         final long expectedMillis = lastModified - (lastModifiedDelta * MILLIS_PER_DAY);
-        timestamp.enrich(lastModified, lastModifiedDelta);
-        final Timestamp expected = new Timestamp().set(expectedMillis);
+        timestamp.adjustBy(lastModified, lastModifiedDelta);
+        final Timestamp expected = new Timestamp().ofUnixTimeMillis(expectedMillis);
         Assert.assertThat(timestamp.getYear(), CoreMatchers.is(expected.getYear()));
         Assert.assertThat(timestamp.getMonth(), CoreMatchers.is(expected.getMonth()));
         Assert.assertThat(timestamp.getDay(), CoreMatchers.is(expected.getDay()));
@@ -187,8 +190,8 @@ public class TimestampTest {
 
     @Test
     public final void shouldEnrichDateInformationFromOtherTimeStamp() {
-        final Timestamp other = new Timestamp().set(UTC_12_01);
-        timestamp.set(0).enrich(other);
+        final Timestamp other = new Timestamp().ofUnixTimeMillis(UTC_12_01);
+        timestamp.ofUnixTimeMillis(0).enrich(other);
 
         Assert.assertThat(timestamp.getYear(), CoreMatchers.is(other.getYear()));
         Assert.assertThat(timestamp.getMonth(), CoreMatchers.is(other.getMonth()));
@@ -197,30 +200,30 @@ public class TimestampTest {
 
     @Test
     public void shouldAddDayDelta() {
-        timestamp.set(0).applyDayDelta(2);
+        timestamp.ofUnixTimeMillis(0).applyDayDelta(2);
 
-        Assert.assertThat(timestamp.getYear(), CoreMatchers.is((short) 1970));
-        Assert.assertThat(timestamp.getMonth(), CoreMatchers.is((byte) 1));
-        Assert.assertThat(timestamp.getDay(), CoreMatchers.is((byte) 3));
+        Assert.assertThat(timestamp.getYear(), CoreMatchers.is(1970));
+        Assert.assertThat(timestamp.getMonth(), CoreMatchers.is(1));
+        Assert.assertThat(timestamp.getDay(), CoreMatchers.is(3));
 
-        timestamp.set(0).applyDayDelta(-2);
+        timestamp.ofUnixTimeMillis(0).applyDayDelta(-2);
 
-        Assert.assertThat(timestamp.getYear(), CoreMatchers.is((short) 1969));
-        Assert.assertThat(timestamp.getMonth(), CoreMatchers.is((byte) 12));
-        Assert.assertThat(timestamp.getDay(), CoreMatchers.is((byte) 30));
+        Assert.assertThat(timestamp.getYear(), CoreMatchers.is(1969));
+        Assert.assertThat(timestamp.getMonth(), CoreMatchers.is(12));
+        Assert.assertThat(timestamp.getDay(), CoreMatchers.is(30));
     }
 
     @Test
     public void shouldWorkWithoutTimezonesAddDayDelta() throws ParseException {
         timestamp.enrich(new Timestamp().enrich("1970-01-01", "(\\d{4}-\\d{2}-\\d{2})", "yyyy-MM-dd").applyDayDelta(1));
 
-        Assert.assertThat(timestamp.getYear(), CoreMatchers.is((short) 1970));
-        Assert.assertThat(timestamp.getMonth(), CoreMatchers.is((byte) 1));
-        Assert.assertThat(timestamp.getDay(), CoreMatchers.is((byte) 2));
-        Assert.assertThat(timestamp.getSeconds(), CoreMatchers.is(Byte.MIN_VALUE));
-        Assert.assertThat(timestamp.getMinute(), CoreMatchers.is(Byte.MIN_VALUE));
-        Assert.assertThat(timestamp.getHour(), CoreMatchers.is(Byte.MIN_VALUE));
-        Assert.assertThat(timestamp.getTimezone(), CoreMatchers.is(Byte.MIN_VALUE));
+        Assert.assertThat(timestamp.getYear(), CoreMatchers.is(1970));
+        Assert.assertThat(timestamp.getMonth(), CoreMatchers.is(1));
+        Assert.assertThat(timestamp.getDay(), CoreMatchers.is( 2));
+        Assert.assertThat(timestamp.getSeconds(), CoreMatchers.is(Integer.MIN_VALUE));
+        Assert.assertThat(timestamp.getMinute(), CoreMatchers.is(Integer.MIN_VALUE));
+        Assert.assertThat(timestamp.getHour(), CoreMatchers.is(Integer.MIN_VALUE));
+        Assert.assertThat(timestamp.getTimezone(), CoreMatchers.is(Integer.MIN_VALUE));
     }
 
 }

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/model/TimestampTest.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/model/TimestampTest.java
@@ -31,7 +31,6 @@ package org.n52.sos.importer.feeder.model;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.Date;
 import java.util.TimeZone;
 
 import org.hamcrest.CoreMatchers;

--- a/feeder/src/test/java/org/n52/sos/importer/feeder/util/DescriptionBuilderTest.java
+++ b/feeder/src/test/java/org/n52/sos/importer/feeder/util/DescriptionBuilderTest.java
@@ -46,8 +46,10 @@ import net.opengis.swe.x101.VectorType;
 import net.opengis.swe.x101.VectorType.Coordinate;
 
 import org.apache.xmlbeans.XmlException;
+import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.n52.oxf.sos.adapter.wrapper.builder.SensorDescriptionBuilder;
@@ -80,7 +82,7 @@ public class DescriptionBuilderTest {
     private final String uomCode = "uom-code";
     private final UnitOfMeasurement uom = new UnitOfMeasurement(uomCode, uomUri);
     //"2013-09-25T15:25:33+02:00"
-    private final Timestamp timeStamp = new Timestamp().set(System.currentTimeMillis());
+    private final Timestamp timeStamp = new Timestamp().ofUnixTimeMillis(System.currentTimeMillis());
     private final int value = 52;
     private final String featureName = "feature-name";
     private final String featureUri = "feature-uri";
@@ -115,116 +117,116 @@ public class DescriptionBuilderTest {
 
     @Test public void
     shouldSetKeywords() {
-        org.junit.Assert.assertThat(system.getKeywordsArray().length, org.hamcrest.Matchers.is(1));
+        Assert.assertThat(system.getKeywordsArray().length, Matchers.is(1));
         final String[] keywordArray = system.getKeywordsArray(0).getKeywordList().getKeywordArray();
-        org.junit.Assert.assertThat(keywordArray.length, org.hamcrest.Matchers.is(3));
-        org.junit.Assert.assertThat(keywordArray, org.hamcrest.Matchers.hasItemInArray(featureName));
-        org.junit.Assert.assertThat(keywordArray, org.hamcrest.Matchers.hasItemInArray(sensorName));
-        org.junit.Assert.assertThat(keywordArray, org.hamcrest.Matchers.hasItemInArray(obsPropName));
+        Assert.assertThat(keywordArray.length, Matchers.is(3));
+        Assert.assertThat(keywordArray, Matchers.hasItemInArray(featureName));
+        Assert.assertThat(keywordArray, Matchers.hasItemInArray(sensorName));
+        Assert.assertThat(keywordArray, Matchers.hasItemInArray(obsPropName));
     }
 
     @Test public void
     shouldSetIdentification() {
-        org.junit.Assert.assertThat(system.getIdentificationArray().length, org.hamcrest.Matchers.is(1));
+        Assert.assertThat(system.getIdentificationArray().length, Matchers.is(1));
         final Identifier[] identifierArray = system.getIdentificationArray(0).getIdentifierList().getIdentifierArray();
-        org.junit.Assert.assertThat(identifierArray.length, org.hamcrest.Matchers.is(3));
+        Assert.assertThat(identifierArray.length, Matchers.is(3));
 
-        org.junit.Assert.assertThat(identifierArray[0].getName(), org.hamcrest.Matchers.is("uniqueID"));
-        org.junit.Assert.assertThat(identifierArray[0].getTerm().getDefinition(),
-                org.hamcrest.Matchers.is("urn:ogc:def:identifier:OGC:1.0:uniqueID"));
-        org.junit.Assert.assertThat(identifierArray[0].getTerm().getValue(), org.hamcrest.Matchers.is(sensorUri));
+        Assert.assertThat(identifierArray[0].getName(), Matchers.is("uniqueID"));
+        Assert.assertThat(identifierArray[0].getTerm().getDefinition(),
+                Matchers.is("urn:ogc:def:identifier:OGC:1.0:uniqueID"));
+        Assert.assertThat(identifierArray[0].getTerm().getValue(), Matchers.is(sensorUri));
 
-        org.junit.Assert.assertThat(identifierArray[1].getName(), org.hamcrest.Matchers.is("longName"));
-        org.junit.Assert.assertThat(identifierArray[1].getTerm().getDefinition(),
-                org.hamcrest.Matchers.is("urn:ogc:def:identifier:OGC:1.0:longName"));
-        org.junit.Assert.assertThat(identifierArray[1].getTerm().getValue(), org.hamcrest.Matchers.is(sensorName));
+        Assert.assertThat(identifierArray[1].getName(), Matchers.is("longName"));
+        Assert.assertThat(identifierArray[1].getTerm().getDefinition(),
+                Matchers.is("urn:ogc:def:identifier:OGC:1.0:longName"));
+        Assert.assertThat(identifierArray[1].getTerm().getValue(), Matchers.is(sensorName));
 
-        org.junit.Assert.assertThat(identifierArray[2].getName(), org.hamcrest.Matchers.is("shortName"));
-        org.junit.Assert.assertThat(identifierArray[2].getTerm().getDefinition(),
-                org.hamcrest.Matchers.is("urn:ogc:def:identifier:OGC:1.0:shortName"));
-        org.junit.Assert.assertThat(identifierArray[2].getTerm().getValue(), org.hamcrest.Matchers.is(sensorName));
+        Assert.assertThat(identifierArray[2].getName(), Matchers.is("shortName"));
+        Assert.assertThat(identifierArray[2].getTerm().getDefinition(),
+                Matchers.is("urn:ogc:def:identifier:OGC:1.0:shortName"));
+        Assert.assertThat(identifierArray[2].getTerm().getValue(), Matchers.is(sensorName));
     }
 
     @Test public void
     shouldSetSensorPosition() {
-        org.junit.Assert.assertThat(system.isSetPosition(), org.hamcrest.Matchers.is(true));
-        org.junit.Assert.assertThat(system.getPosition().getName(), org.hamcrest.Matchers.is("sensorPosition"));
+        Assert.assertThat(system.isSetPosition(), Matchers.is(true));
+        Assert.assertThat(system.getPosition().getName(), Matchers.is("sensorPosition"));
         final VectorType vector = system.getPosition().getPosition().getLocation().getVector();
-        org.junit.Assert.assertThat(vector.getId(), org.hamcrest.Matchers.is("SYSTEM_LOCATION"));
-        org.junit.Assert.assertThat(vector.getCoordinateArray().length, org.hamcrest.Matchers.is(3));
+        Assert.assertThat(vector.getId(), Matchers.is("SYSTEM_LOCATION"));
+        Assert.assertThat(vector.getCoordinateArray().length, Matchers.is(3));
 
-        org.junit.Assert.assertThat(vector.getCoordinateArray(0).getName(), org.hamcrest.Matchers.is(easting));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(0).getQuantity().getAxisID(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase("x")));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(0).getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase(degree)));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(0).getQuantity().getValue(),
-                org.hamcrest.Matchers.is(longitude));
+        Assert.assertThat(vector.getCoordinateArray(0).getName(), Matchers.is(easting));
+        Assert.assertThat(vector.getCoordinateArray(0).getQuantity().getAxisID(),
+                Matchers.is(Matchers.equalToIgnoringCase("x")));
+        Assert.assertThat(vector.getCoordinateArray(0).getQuantity().getUom().getCode(),
+                Matchers.is(Matchers.equalToIgnoringCase(degree)));
+        Assert.assertThat(vector.getCoordinateArray(0).getQuantity().getValue(),
+                Matchers.is(longitude));
 
-        org.junit.Assert.assertThat(vector.getCoordinateArray(1).getName(), org.hamcrest.Matchers.is(northing));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(1).getQuantity().getAxisID(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase("y")));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(1).getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase(degree)));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(1).getQuantity().getValue(),
-                org.hamcrest.Matchers.is(latitude));
+        Assert.assertThat(vector.getCoordinateArray(1).getName(), Matchers.is(northing));
+        Assert.assertThat(vector.getCoordinateArray(1).getQuantity().getAxisID(),
+                Matchers.is(Matchers.equalToIgnoringCase("y")));
+        Assert.assertThat(vector.getCoordinateArray(1).getQuantity().getUom().getCode(),
+                Matchers.is(Matchers.equalToIgnoringCase(degree)));
+        Assert.assertThat(vector.getCoordinateArray(1).getQuantity().getValue(),
+                Matchers.is(latitude));
 
-        org.junit.Assert.assertThat(vector.getCoordinateArray(2).getName(), org.hamcrest.Matchers.is("altitude"));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(2).getQuantity().getAxisID(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase("z")));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(2).getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase(meter)));
-        org.junit.Assert.assertThat(vector.getCoordinateArray(2).getQuantity().getValue(),
-                org.hamcrest.Matchers.is(altitude));
+        Assert.assertThat(vector.getCoordinateArray(2).getName(), Matchers.is("altitude"));
+        Assert.assertThat(vector.getCoordinateArray(2).getQuantity().getAxisID(),
+                Matchers.is(Matchers.equalToIgnoringCase("z")));
+        Assert.assertThat(vector.getCoordinateArray(2).getQuantity().getUom().getCode(),
+                Matchers.is(Matchers.equalToIgnoringCase(meter)));
+        Assert.assertThat(vector.getCoordinateArray(2).getQuantity().getValue(),
+                Matchers.is(altitude));
     }
 
     @Test public void
     shouldSetInputs() {
-        org.junit.Assert.assertThat(system.isSetInputs(), org.hamcrest.Matchers.is(true));
-        org.junit.Assert.assertThat(
-                system.getInputs().getInputList().getInputArray().length, org.hamcrest.Matchers.is(1));
-        org.junit.Assert.assertThat(system.getInputs().getInputList().getInputArray(0).getName(),
-                org.hamcrest.Matchers.is(obsPropName));
-        org.junit.Assert.assertThat(
+        Assert.assertThat(system.isSetInputs(), Matchers.is(true));
+        Assert.assertThat(
+                system.getInputs().getInputList().getInputArray().length, Matchers.is(1));
+        Assert.assertThat(system.getInputs().getInputList().getInputArray(0).getName(),
+                Matchers.is(obsPropName));
+        Assert.assertThat(
                 system.getInputs().getInputList().getInputArray(0).getObservableProperty().getDefinition(),
-                org.hamcrest.Matchers.is(obsPropUri));
+                Matchers.is(obsPropUri));
     }
 
     @Test public void
     shouldSetOutputs() {
-        org.junit.Assert.assertThat(system.isSetOutputs(), org.hamcrest.Matchers.is(true));
-        org.junit.Assert.assertThat(
+        Assert.assertThat(system.isSetOutputs(), Matchers.is(true));
+        Assert.assertThat(
                 system.getOutputs().getOutputList().getOutputArray().length,
-                org.hamcrest.Matchers.is(1));
-        org.junit.Assert.assertThat(system.getOutputs().getOutputList().getOutputArray(0).getName(),
-                org.hamcrest.Matchers.is(obsPropName));
-        org.junit.Assert.assertThat(system.getOutputs().getOutputList().getOutputArray(0).getQuantity().getDefinition(),
-                org.hamcrest.Matchers.is(obsPropUri));
-        org.junit.Assert.assertThat(
+                Matchers.is(1));
+        Assert.assertThat(system.getOutputs().getOutputList().getOutputArray(0).getName(),
+                Matchers.is(obsPropName));
+        Assert.assertThat(system.getOutputs().getOutputList().getOutputArray(0).getQuantity().getDefinition(),
+                Matchers.is(obsPropUri));
+        Assert.assertThat(
                 system.getOutputs().getOutputList().getOutputArray(0).getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(uomCode));
+                Matchers.is(uomCode));
     }
 
     @Test public void
     shouldSetOfferings() {
         final Capabilities offering = getCapabilitiesByName("offerings");
         final AnyScalarPropertyType field = ((SimpleDataRecordType) offering.getAbstractDataRecord()).getFieldArray(0);
-        org.junit.Assert.assertThat(field.getName(), org.hamcrest.Matchers.is(offeringName));
-        org.junit.Assert.assertThat(field.isSetText(), org.hamcrest.Matchers.is(true));
-        org.junit.Assert.assertThat(field.getText().getDefinition(),
-                org.hamcrest.Matchers.is("urn:ogc:def:identifier:OGC:1.0:offeringID"));
-        org.junit.Assert.assertThat(field.getText().getValue(), org.hamcrest.Matchers.is(offeringUri));
+        Assert.assertThat(field.getName(), Matchers.is(offeringName));
+        Assert.assertThat(field.isSetText(), Matchers.is(true));
+        Assert.assertThat(field.getText().getDefinition(),
+                Matchers.is("urn:ogc:def:identifier:OGC:1.0:offeringID"));
+        Assert.assertThat(field.getText().getValue(), Matchers.is(offeringUri));
     }
 
     @Test public void
     shouldSetFeatureOfInterest() {
         final Capabilities features = getCapabilitiesByName("featuresOfInterest");
         final DataComponentPropertyType field = ((DataRecordType) features.getAbstractDataRecord()).getFieldArray(0);
-        org.junit.Assert.assertThat(field.getName(), org.hamcrest.Matchers.is("featureOfInterestID"));
-        org.junit.Assert.assertThat(field.isSetText(), org.hamcrest.Matchers.is(true));
-        org.junit.Assert.assertThat(field.getText().getDefinition(),
-                org.hamcrest.Matchers.is("http://www.opengis.net/def/featureOfInterest/identifier"));
-        org.junit.Assert.assertThat(field.getText().getValue(), org.hamcrest.Matchers.is(featureUri));
+        Assert.assertThat(field.getName(), Matchers.is("featureOfInterestID"));
+        Assert.assertThat(field.isSetText(), Matchers.is(true));
+        Assert.assertThat(field.getText().getDefinition(),
+                Matchers.is("http://www.opengis.net/def/featureOfInterest/identifier"));
+        Assert.assertThat(field.getText().getValue(), Matchers.is(featureUri));
     }
 
     @Test public void
@@ -234,66 +236,66 @@ public class DescriptionBuilderTest {
         final Capabilities observedBBOX = getCapabilitiesByName(observedBBox);
         final DataComponentPropertyType field =
                 ((DataRecordType) observedBBOX.getAbstractDataRecord()).getFieldArray(0);
-        org.junit.Assert.assertThat(field.getName(), org.hamcrest.Matchers.is(observedBBox));
+        Assert.assertThat(field.getName(), Matchers.is(observedBBox));
         final EnvelopeType envelope = EnvelopeType.Factory.parse(field.getAbstractDataRecord().newInputStream());
-        org.junit.Assert.assertThat(envelope.getDefinition(),
-                org.hamcrest.Matchers.is("urn:ogc:def:property:OGC:1.0:observedBBOX"));
+        Assert.assertThat(envelope.getDefinition(),
+                Matchers.is("urn:ogc:def:property:OGC:1.0:observedBBOX"));
 
-        org.junit.Assert.assertThat(envelope.isSetReferenceFrame(), org.hamcrest.Matchers.is(true));
-        org.junit.Assert.assertThat(envelope.getReferenceFrame(),
-                org.hamcrest.Matchers.is(SensorDescriptionBuilder.EPSG_CODE_PREFIX + 4326));
+        Assert.assertThat(envelope.isSetReferenceFrame(), Matchers.is(true));
+        Assert.assertThat(envelope.getReferenceFrame(),
+                Matchers.is(SensorDescriptionBuilder.EPSG_CODE_PREFIX + 4326));
         final Coordinate[] lcCoords = envelope.getLowerCorner().getVector().getCoordinateArray();
 
-        org.junit.Assert.assertThat(lcCoords.length, org.hamcrest.Matchers.is(2));
+        Assert.assertThat(lcCoords.length, Matchers.is(2));
 
-        org.junit.Assert.assertThat(lcCoords[0].getName(), org.hamcrest.Matchers.is(easting));
-        org.junit.Assert.assertThat(lcCoords[0].getQuantity().getAxisID(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase("x")));
-        org.junit.Assert.assertThat(lcCoords[0].getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase(degree)));
-        org.junit.Assert.assertThat(lcCoords[0].getQuantity().getValue(), org.hamcrest.Matchers.is(longitude));
+        Assert.assertThat(lcCoords[0].getName(), Matchers.is(easting));
+        Assert.assertThat(lcCoords[0].getQuantity().getAxisID(),
+                Matchers.is(Matchers.equalToIgnoringCase("x")));
+        Assert.assertThat(lcCoords[0].getQuantity().getUom().getCode(),
+                Matchers.is(Matchers.equalToIgnoringCase(degree)));
+        Assert.assertThat(lcCoords[0].getQuantity().getValue(), Matchers.is(longitude));
 
-        org.junit.Assert.assertThat(lcCoords[1].getName(), org.hamcrest.Matchers.is(northing));
-        org.junit.Assert.assertThat(lcCoords[1].getQuantity().getAxisID(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase("y")));
-        org.junit.Assert.assertThat(lcCoords[1].getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase(degree)));
-        org.junit.Assert.assertThat(lcCoords[1].getQuantity().getValue(), org.hamcrest.Matchers.is(latitude));
+        Assert.assertThat(lcCoords[1].getName(), Matchers.is(northing));
+        Assert.assertThat(lcCoords[1].getQuantity().getAxisID(),
+                Matchers.is(Matchers.equalToIgnoringCase("y")));
+        Assert.assertThat(lcCoords[1].getQuantity().getUom().getCode(),
+                Matchers.is(Matchers.equalToIgnoringCase(degree)));
+        Assert.assertThat(lcCoords[1].getQuantity().getValue(), Matchers.is(latitude));
 
         final Coordinate[] ucCoords = envelope.getUpperCorner().getVector().getCoordinateArray();
 
-        org.junit.Assert.assertThat(ucCoords.length, org.hamcrest.Matchers.is(2));
+        Assert.assertThat(ucCoords.length, Matchers.is(2));
 
-        org.junit.Assert.assertThat(ucCoords[0].getName(), org.hamcrest.Matchers.is(easting));
-        org.junit.Assert.assertThat(ucCoords[0].getQuantity().getAxisID(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase("x")));
-        org.junit.Assert.assertThat(ucCoords[0].getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase(degree)));
-        org.junit.Assert.assertThat(ucCoords[0].getQuantity().getValue(), org.hamcrest.Matchers.is(longitude));
+        Assert.assertThat(ucCoords[0].getName(), Matchers.is(easting));
+        Assert.assertThat(ucCoords[0].getQuantity().getAxisID(),
+                Matchers.is(Matchers.equalToIgnoringCase("x")));
+        Assert.assertThat(ucCoords[0].getQuantity().getUom().getCode(),
+                Matchers.is(Matchers.equalToIgnoringCase(degree)));
+        Assert.assertThat(ucCoords[0].getQuantity().getValue(), Matchers.is(longitude));
 
-        org.junit.Assert.assertThat(ucCoords[1].getName(), org.hamcrest.Matchers.is(northing));
-        org.junit.Assert.assertThat(ucCoords[1].getQuantity().getAxisID(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase("y")));
-        org.junit.Assert.assertThat(ucCoords[1].getQuantity().getUom().getCode(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.equalToIgnoringCase(degree)));
-        org.junit.Assert.assertThat(ucCoords[1].getQuantity().getValue(), org.hamcrest.Matchers.is(latitude));
+        Assert.assertThat(ucCoords[1].getName(), Matchers.is(northing));
+        Assert.assertThat(ucCoords[1].getQuantity().getAxisID(),
+                Matchers.is(Matchers.equalToIgnoringCase("y")));
+        Assert.assertThat(ucCoords[1].getQuantity().getUom().getCode(),
+                Matchers.is(Matchers.equalToIgnoringCase(degree)));
+        Assert.assertThat(ucCoords[1].getQuantity().getValue(), Matchers.is(latitude));
     }
 
     @Test public void
     shouldSetValidTime()
             throws XmlException, IOException {
         final TimePeriodType validTime = system.getValidTime().getTimePeriod();
-        org.junit.Assert.assertThat(validTime.getBeginPosition().getObjectValue(),
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.notNullValue()));
+        Assert.assertThat(validTime.getBeginPosition().getObjectValue(),
+                Matchers.is(Matchers.notNullValue()));
         final long durationMillis =
                 new Interval(new DateTime(validTime.getBeginPosition().getStringValue()).getMillis(),
                         System.currentTimeMillis()).toDurationMillis();
-        org.junit.Assert.assertThat(durationMillis,
-                org.hamcrest.Matchers.is(org.hamcrest.Matchers.lessThanOrEqualTo(2000L)));
-        org.junit.Assert.assertThat(validTime.getEndPosition().isSetIndeterminatePosition(),
-                org.hamcrest.Matchers.is(true));
-        org.junit.Assert.assertThat(validTime.getEndPosition().getIndeterminatePosition().toString(),
-                org.hamcrest.Matchers.is("unknown"));
+        Assert.assertThat(durationMillis,
+                Matchers.is(Matchers.lessThanOrEqualTo(2000L)));
+        Assert.assertThat(validTime.getEndPosition().isSetIndeterminatePosition(),
+                Matchers.is(true));
+        Assert.assertThat(validTime.getEndPosition().getIndeterminatePosition().toString(),
+                Matchers.is("unknown"));
         // test for valid time -> set by server
     }
 
@@ -305,7 +307,7 @@ public class DescriptionBuilderTest {
                 return capabilities;
             }
         }
-        org.junit.Assert.fail("sml:capabilities element with name '" + name + "' not found!");
+        Assert.fail("sml:capabilities element with name '" + name + "' not found!");
         return null;
     }
 }

--- a/feeder/src/test/resources/issue-078/data_config.xml
+++ b/feeder/src/test/resources/issue-078/data_config.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SosImportConfiguration xsi:schemaLocation="https://raw.githubusercontent.com/52North/sos-importer/master/bindings/src/main/resources/import-configuration.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://52north.org/sensorweb/sos/importer/0.4/">
+    <DataFile referenceIsARegularExpression="false">
+        <LocalFile>
+            <Path>src/test/resources/issue-078/data_obs.csv</Path>
+            <Encoding>UTF-8</Encoding>
+        </LocalFile>
+    </DataFile>
+    <SosMetadata insertSweArrayObservationTimeoutBuffer="25">
+        <URL>http://localhost:8080/52n-sos-webapp/service</URL>
+        <Offering generate="true"/>
+        <Version>2.0.0</Version>
+        <Binding>POX</Binding>
+    </SosMetadata>
+    <CsvMetadata>
+        <ColumnAssignments>
+            <Column>
+                <Number>0</Number>
+                <Type>DATE_TIME</Type>
+                <Metadata>
+                    <Key>GROUP</Key>
+                    <Value>1</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>PARSE_PATTERN</Key>
+                    <Value>yyyy-MM-dd'T'HH:mm:ss</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>COMBINATION</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TIME_ZONE</Key>
+                    <Value>0</Value>
+                </Metadata>
+            </Column>
+            <Column>
+                <Number>1</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+            <Column>
+                <Number>2</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+        </ColumnAssignments>
+        <DecimalSeparator>.</DecimalSeparator>
+        <FirstLineWithData>0</FirstLineWithData>
+        <Parameter>
+            <CommentIndicator>#</CommentIndicator>
+            <ColumnSeparator>,</ColumnSeparator>
+            <TextIndicator>"</TextIndicator>
+        </Parameter>
+        <UseHeader>false</UseHeader>
+    </CsvMetadata>
+    <AdditionalMetadata>
+        <Metadata>
+            <Key>IMPORT_STRATEGY</Key>
+            <Value>SweArrayObservationWithSplitExtension</Value>
+        </Metadata>
+        <Metadata>
+            <Key>HUNK_SIZE</Key>
+            <Value>5000</Value>
+        </Metadata>
+        <Sensor>
+            <ManualResource>
+                <ID>sensor965319032</ID>
+                <URI>http://example.com/krypto-graph</URI>
+                <Name>krypto-graph</Name>
+            </ManualResource>
+        </Sensor>
+        <FeatureOfInterest>
+            <SpatialResource>
+                <ID>foi473980759</ID>
+                <URI>http://superman.me/home</URI>
+                <Name>Superman's Home</Name>
+                <Position>
+                    <Alt unit="meters">0.0</Alt>
+                    <EPSGCode>4326</EPSGCode>
+                    <Lat unit="deg">0.0</Lat>
+                    <Long unit="deg">0.0</Long>
+                </Position>
+            </SpatialResource>
+        </FeatureOfInterest>
+    </AdditionalMetadata>
+</SosImportConfiguration>

--- a/feeder/src/test/resources/issue-078/data_config_with-zone-Z.xml
+++ b/feeder/src/test/resources/issue-078/data_config_with-zone-Z.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SosImportConfiguration xsi:schemaLocation="https://raw.githubusercontent.com/52North/sos-importer/master/bindings/src/main/resources/import-configuration.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://52north.org/sensorweb/sos/importer/0.4/">
+    <DataFile referenceIsARegularExpression="false">
+        <LocalFile>
+            <Path>src/test/resources/issue-078/data_obs.csv</Path>
+            <Encoding>UTF-8</Encoding>
+        </LocalFile>
+    </DataFile>
+    <SosMetadata insertSweArrayObservationTimeoutBuffer="25">
+        <URL>http://localhost:8080/52n-sos-webapp/service</URL>
+        <Offering generate="true"/>
+        <Version>2.0.0</Version>
+        <Binding>POX</Binding>
+    </SosMetadata>
+    <CsvMetadata>
+        <ColumnAssignments>
+            <Column>
+                <Number>0</Number>
+                <Type>DATE_TIME</Type>
+                <Metadata>
+                    <Key>GROUP</Key>
+                    <Value>1</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>PARSE_PATTERN</Key>
+                    <Value>yyyy-MM-dd'T'HH:mm:ss'Z'</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>COMBINATION</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TIME_ZONE</Key>
+                    <Value>0</Value>
+                </Metadata>
+            </Column>
+            <Column>
+                <Number>1</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+            <Column>
+                <Number>2</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+        </ColumnAssignments>
+        <DecimalSeparator>.</DecimalSeparator>
+        <FirstLineWithData>0</FirstLineWithData>
+        <Parameter>
+            <CommentIndicator>#</CommentIndicator>
+            <ColumnSeparator>,</ColumnSeparator>
+            <TextIndicator>"</TextIndicator>
+        </Parameter>
+        <UseHeader>false</UseHeader>
+    </CsvMetadata>
+    <AdditionalMetadata>
+        <Metadata>
+            <Key>IMPORT_STRATEGY</Key>
+            <Value>SweArrayObservationWithSplitExtension</Value>
+        </Metadata>
+        <Metadata>
+            <Key>HUNK_SIZE</Key>
+            <Value>5000</Value>
+        </Metadata>
+        <Sensor>
+            <ManualResource>
+                <ID>sensor965319032</ID>
+                <URI>http://example.com/krypto-graph</URI>
+                <Name>krypto-graph</Name>
+            </ManualResource>
+        </Sensor>
+        <FeatureOfInterest>
+            <SpatialResource>
+                <ID>foi473980759</ID>
+                <URI>http://superman.me/home</URI>
+                <Name>Superman's Home</Name>
+                <Position>
+                    <Alt unit="meters">0.0</Alt>
+                    <EPSGCode>4326</EPSGCode>
+                    <Lat unit="deg">0.0</Lat>
+                    <Long unit="deg">0.0</Long>
+                </Position>
+            </SpatialResource>
+        </FeatureOfInterest>
+    </AdditionalMetadata>
+</SosImportConfiguration>

--- a/feeder/src/test/resources/issue-078/data_config_with-zone-offset.xml
+++ b/feeder/src/test/resources/issue-078/data_config_with-zone-offset.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SosImportConfiguration xsi:schemaLocation="https://raw.githubusercontent.com/52North/sos-importer/master/bindings/src/main/resources/import-configuration.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://52north.org/sensorweb/sos/importer/0.4/">
+    <DataFile referenceIsARegularExpression="false">
+        <LocalFile>
+            <Path>src/test/resources/issue-078/data_obs.csv</Path>
+            <Encoding>UTF-8</Encoding>
+        </LocalFile>
+    </DataFile>
+    <SosMetadata insertSweArrayObservationTimeoutBuffer="25">
+        <URL>http://localhost:8080/52n-sos-webapp/service</URL>
+        <Offering generate="true"/>
+        <Version>2.0.0</Version>
+        <Binding>POX</Binding>
+    </SosMetadata>
+    <CsvMetadata>
+        <ColumnAssignments>
+            <Column>
+                <Number>0</Number>
+                <Type>DATE_TIME</Type>
+                <Metadata>
+                    <Key>GROUP</Key>
+                    <Value>1</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>PARSE_PATTERN</Key>
+                    <Value>yyyy-MM-dd'T'HH:mm:ssXXX</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>COMBINATION</Value>
+                </Metadata>
+            </Column>
+            <Column>
+                <Number>1</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+            <Column>
+                <Number>2</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+        </ColumnAssignments>
+        <DecimalSeparator>.</DecimalSeparator>
+        <FirstLineWithData>0</FirstLineWithData>
+        <Parameter>
+            <CommentIndicator>#</CommentIndicator>
+            <ColumnSeparator>,</ColumnSeparator>
+            <TextIndicator>"</TextIndicator>
+        </Parameter>
+        <UseHeader>false</UseHeader>
+    </CsvMetadata>
+    <AdditionalMetadata>
+        <Metadata>
+            <Key>IMPORT_STRATEGY</Key>
+            <Value>SweArrayObservationWithSplitExtension</Value>
+        </Metadata>
+        <Metadata>
+            <Key>HUNK_SIZE</Key>
+            <Value>5000</Value>
+        </Metadata>
+        <Sensor>
+            <ManualResource>
+                <ID>sensor965319032</ID>
+                <URI>http://example.com/krypto-graph</URI>
+                <Name>krypto-graph</Name>
+            </ManualResource>
+        </Sensor>
+        <FeatureOfInterest>
+            <SpatialResource>
+                <ID>foi473980759</ID>
+                <URI>http://superman.me/home</URI>
+                <Name>Superman's Home</Name>
+                <Position>
+                    <Alt unit="meters">0.0</Alt>
+                    <EPSGCode>4326</EPSGCode>
+                    <Lat unit="deg">0.0</Lat>
+                    <Long unit="deg">0.0</Long>
+                </Position>
+            </SpatialResource>
+        </FeatureOfInterest>
+    </AdditionalMetadata>
+</SosImportConfiguration>

--- a/feeder/src/test/resources/issue-078/data_config_with-zone-z.xml
+++ b/feeder/src/test/resources/issue-078/data_config_with-zone-z.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SosImportConfiguration xsi:schemaLocation="https://raw.githubusercontent.com/52North/sos-importer/master/bindings/src/main/resources/import-configuration.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://52north.org/sensorweb/sos/importer/0.4/">
+    <DataFile referenceIsARegularExpression="false">
+        <LocalFile>
+            <Path>src/test/resources/issue-078/data_obs.csv</Path>
+            <Encoding>UTF-8</Encoding>
+        </LocalFile>
+    </DataFile>
+    <SosMetadata insertSweArrayObservationTimeoutBuffer="25">
+        <URL>http://localhost:8080/52n-sos-webapp/service</URL>
+        <Offering generate="true"/>
+        <Version>2.0.0</Version>
+        <Binding>POX</Binding>
+    </SosMetadata>
+    <CsvMetadata>
+        <ColumnAssignments>
+            <Column>
+                <Number>0</Number>
+                <Type>DATE_TIME</Type>
+                <Metadata>
+                    <Key>GROUP</Key>
+                    <Value>1</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>PARSE_PATTERN</Key>
+                    <Value>yyyy-MM-dd'T'HH:mm:ssz</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>COMBINATION</Value>
+                </Metadata>
+            </Column>
+            <Column>
+                <Number>1</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+            <Column>
+                <Number>2</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+        </ColumnAssignments>
+        <DecimalSeparator>.</DecimalSeparator>
+        <FirstLineWithData>0</FirstLineWithData>
+        <Parameter>
+            <CommentIndicator>#</CommentIndicator>
+            <ColumnSeparator>,</ColumnSeparator>
+            <TextIndicator>"</TextIndicator>
+        </Parameter>
+        <UseHeader>false</UseHeader>
+    </CsvMetadata>
+    <AdditionalMetadata>
+        <Metadata>
+            <Key>IMPORT_STRATEGY</Key>
+            <Value>SweArrayObservationWithSplitExtension</Value>
+        </Metadata>
+        <Metadata>
+            <Key>HUNK_SIZE</Key>
+            <Value>5000</Value>
+        </Metadata>
+        <Sensor>
+            <ManualResource>
+                <ID>sensor965319032</ID>
+                <URI>http://example.com/krypto-graph</URI>
+                <Name>krypto-graph</Name>
+            </ManualResource>
+        </Sensor>
+        <FeatureOfInterest>
+            <SpatialResource>
+                <ID>foi473980759</ID>
+                <URI>http://superman.me/home</URI>
+                <Name>Superman's Home</Name>
+                <Position>
+                    <Alt unit="meters">0.0</Alt>
+                    <EPSGCode>4326</EPSGCode>
+                    <Lat unit="deg">0.0</Lat>
+                    <Long unit="deg">0.0</Long>
+                </Position>
+            </SpatialResource>
+        </FeatureOfInterest>
+    </AdditionalMetadata>
+</SosImportConfiguration>

--- a/feeder/src/test/resources/issue-078/data_config_without-zone.xml
+++ b/feeder/src/test/resources/issue-078/data_config_without-zone.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SosImportConfiguration xsi:schemaLocation="https://raw.githubusercontent.com/52North/sos-importer/master/bindings/src/main/resources/import-configuration.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://52north.org/sensorweb/sos/importer/0.4/">
+    <DataFile referenceIsARegularExpression="false">
+        <LocalFile>
+            <Path>src/test/resources/issue-078/data_obs.csv</Path>
+            <Encoding>UTF-8</Encoding>
+        </LocalFile>
+    </DataFile>
+    <SosMetadata insertSweArrayObservationTimeoutBuffer="25">
+        <URL>http://localhost:8080/52n-sos-webapp/service</URL>
+        <Offering generate="true"/>
+        <Version>2.0.0</Version>
+        <Binding>POX</Binding>
+    </SosMetadata>
+    <CsvMetadata>
+        <ColumnAssignments>
+            <Column>
+                <Number>0</Number>
+                <Type>DATE_TIME</Type>
+                <Metadata>
+                    <Key>GROUP</Key>
+                    <Value>1</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>PARSE_PATTERN</Key>
+                    <Value>yyyy-MM-dd'T'HH:mm:ss</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>COMBINATION</Value>
+                </Metadata>
+                <Metadata>
+                    <Key>TIME_ZONE</Key>
+                    <Value>0</Value>
+                </Metadata>
+            </Column>
+            <Column>
+                <Number>1</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+            <Column>
+                <Number>2</Number>
+                <Type>MEASURED_VALUE</Type>
+                <Metadata>
+                    <Key>TYPE</Key>
+                    <Value>NUMERIC</Value>
+                </Metadata>
+                <RelatedFOI>
+                    <IdRef>foi473980759</IdRef>
+                </RelatedFOI>
+                <RelatedSensor>
+                    <IdRef>sensor965319032</IdRef>
+                </RelatedSensor>
+            </Column>
+        </ColumnAssignments>
+        <DecimalSeparator>.</DecimalSeparator>
+        <FirstLineWithData>0</FirstLineWithData>
+        <Parameter>
+            <CommentIndicator>#</CommentIndicator>
+            <ColumnSeparator>,</ColumnSeparator>
+            <TextIndicator>"</TextIndicator>
+        </Parameter>
+        <UseHeader>false</UseHeader>
+    </CsvMetadata>
+    <AdditionalMetadata>
+        <Metadata>
+            <Key>IMPORT_STRATEGY</Key>
+            <Value>SweArrayObservationWithSplitExtension</Value>
+        </Metadata>
+        <Metadata>
+            <Key>HUNK_SIZE</Key>
+            <Value>5000</Value>
+        </Metadata>
+        <Sensor>
+            <ManualResource>
+                <ID>sensor965319032</ID>
+                <URI>http://example.com/krypto-graph</URI>
+                <Name>krypto-graph</Name>
+            </ManualResource>
+        </Sensor>
+        <FeatureOfInterest>
+            <SpatialResource>
+                <ID>foi473980759</ID>
+                <URI>http://superman.me/home</URI>
+                <Name>Superman's Home</Name>
+                <Position>
+                    <Alt unit="meters">0.0</Alt>
+                    <EPSGCode>4326</EPSGCode>
+                    <Lat unit="deg">0.0</Lat>
+                    <Long unit="deg">0.0</Long>
+                </Position>
+            </SpatialResource>
+        </FeatureOfInterest>
+    </AdditionalMetadata>
+</SosImportConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -317,8 +317,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.6.1</version>
                     <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
+                        <source>1.8</source>
+                        <target>1.8</target>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/wizard/src/main/java/org/n52/sos/importer/controller/Step1Controller.java
+++ b/wizard/src/main/java/org/n52/sos/importer/controller/Step1Controller.java
@@ -345,7 +345,6 @@ public class Step1Controller extends StepController {
                 sb.append(line).append("\n");
                 csvFileRowCount++;
             }
-            br.close();
         } catch (final IOException ioe) {
             LOG.error(
                     new StringBuffer("Problem while reading CSV file \"")

--- a/wizard/src/main/java/org/n52/sos/importer/model/Step2Model.java
+++ b/wizard/src/main/java/org/n52/sos/importer/model/Step2Model.java
@@ -106,9 +106,9 @@ public class Step2Model implements StepModel {
         this.csvFileContent = csvFileContent;
 
         final EditableComboBoxItems items = EditableComboBoxItems.getInstance();
-        columnSeparator = (String) items.getColumnSeparators().getElementAt(0);
-        commentIndicator = (String) items.getCommentIndicators().getElementAt(0);
-        textQualifier = (String) items.getTextQualifiers().getElementAt(0);
+        columnSeparator = items.getColumnSeparators().getElementAt(0);
+        commentIndicator = items.getCommentIndicators().getElementAt(0);
+        textQualifier = items.getTextQualifiers().getElementAt(0);
         firstLineWithData = 0;
         csvFileRowRount = csvFileRowCount;
     }

--- a/wizard/src/main/java/org/n52/sos/importer/view/combobox/EditableJComboBoxPanel.java
+++ b/wizard/src/main/java/org/n52/sos/importer/view/combobox/EditableJComboBoxPanel.java
@@ -61,9 +61,9 @@ import org.slf4j.LoggerFactory;
  * @author Raimund
  * @version $Id: $Id
  */
-public class EditableJComboBoxPanel extends JPanel {
+public final class EditableJComboBoxPanel extends JPanel {
 
-    private static final Logger logger = LoggerFactory.getLogger(EditableJComboBoxPanel.class);
+    private static final Logger LOG = LoggerFactory.getLogger(EditableJComboBoxPanel.class);
 
     private static final long serialVersionUID = 1L;
 
@@ -79,7 +79,7 @@ public class EditableJComboBoxPanel extends JPanel {
 
     private final DefaultComboBoxModel<String> model;
 
-    private ActionListener selectionChanged;
+    private final ActionListener selectionChanged;
 
     private final JButton newItemButton;
 
@@ -104,7 +104,7 @@ public class EditableJComboBoxPanel extends JPanel {
         super();
         this.model = model;
         label = new JLabel(labelName + ":   ");
-        comboBox = new JComboBox<String>(model);
+        comboBox = new JComboBox<>(model);
         comboBox.setToolTipText(toolTip);
 
         if (model.getSize() == 0 || (model.getSize() == 1 && model.getElementAt(0).equals(""))) {
@@ -189,11 +189,11 @@ public class EditableJComboBoxPanel extends JPanel {
     protected JButton createIconButton(final String fileName, final String toolTip) {
         final JButton iconButton = new JButton();
         final URL imgURL = getClass().getResource(ICON_FILE_PATH + fileName);
-        ImageIcon icon = null;
+        ImageIcon icon;
         if (imgURL != null) {
             icon = new ImageIcon(imgURL);
         } else {
-            logger.error("Couldn't find file " + fileName + " for icon");
+            LOG.error("Couldn't find file " + fileName + " for icon");
             return null;
         }
 
@@ -342,11 +342,10 @@ public class EditableJComboBoxPanel extends JPanel {
             return " ";
         } else {
             int maxWhiteSpaces = 0;
-            int whiteSpaces = 0;
             for (int i = 0; i < model.getSize(); i++) {
-                final String item = (String) model.getElementAt(i);
+                final String item = model.getElementAt(i);
 
-                whiteSpaces = 0;
+                int whiteSpaces = 0;
                 for (final char ch: item.toCharArray()) {
                     if (Character.isWhitespace(ch)) {
                         whiteSpaces++;
@@ -358,7 +357,7 @@ public class EditableJComboBoxPanel extends JPanel {
                 }
             }
 
-            StringBuffer newBiggestWhiteSpace = new StringBuffer(" ");
+            StringBuilder newBiggestWhiteSpace = new StringBuilder(" ");
             for (int j = 0; j < maxWhiteSpaces; j++) {
                 newBiggestWhiteSpace.append(" ");
             }

--- a/wizard/src/main/java/org/n52/sos/importer/view/step3/CombinationPanel.java
+++ b/wizard/src/main/java/org/n52/sos/importer/view/step3/CombinationPanel.java
@@ -179,7 +179,7 @@ public abstract class CombinationPanel extends SelectionPanel {
         if (logger.isTraceEnabled()) {
             logger.trace("setDefaultSelection()");
         }
-        final String pattern = (String) getPatterns().getElementAt(0);
+        final String pattern = getPatterns().getElementAt(0);
         final String group = getGroupItems()[0];
         patternComboBox.setSelectedItem(pattern);
         getCombination().setPattern(pattern);

--- a/wizard/src/main/resources/org/n52/sos/importer/tooltips/tooltips_de.properties
+++ b/wizard/src/main/resources/org/n52/sos/importer/tooltips/tooltips_de.properties
@@ -136,7 +136,7 @@ h - Stunde im Format am/pm (von 1 bis 12)<br>\
 m - Minute in der Stunde (z.B. 30)<br>\
 s - Sekunde in der Minute (z.B. 55)<br>\
 S - Millisekunde (z.B. 978)<br>\
-z -	Generelle Zeitzone (z.B. Pacific Standard Time; PST; GMT-08:00<br>\
+XXX - ISO 8601 Zeitzone (z.B. -08:00)<br>\
 Z - RFC 822 Zeitzone (z.B. -0800)<br>\
 </html>
 DateAndTime=<html>\

--- a/wizard/src/main/resources/org/n52/sos/importer/tooltips/tooltips_en.properties
+++ b/wizard/src/main/resources/org/n52/sos/importer/tooltips/tooltips_en.properties
@@ -135,7 +135,7 @@ h - Hour in am/pm (from 1 to 12)<br>\
 m - Minute in hour (e.g. 30)<br>\
 s - Second in minute (e.g. 55)<br>\
 S - Millisecond (e.g. 978)<br>\
-z -	General time zone (e.g. Pacific Standard Time; PST; GMT-08:00<br>\
+XXX - ISO 8601 Time zone (e.g. -08:00)<br>\
 Z - RFC 822 Time zone (e.g. -0800)<br>\
 </html>
 DateAndTime=<html>\


### PR DESCRIPTION
- Fixes #78 
- Start switch to `java.time`
- Requires java 8 as minimal version